### PR TITLE
Create Infrastructure and deployment for Service using Terraform

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,28 @@
+name: Deploy
+on:
+  push:
+    branches: main
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.CI_CD_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.CI_CD_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Build and push images
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.login-ecr.outputs.registry }}/wca-registration:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,6 +3,7 @@ services:
   wca_registration:
     build:
       context: .
+      dockerfile: dockerfile.dev
     ports:
       - "3001:3000"
     environment:
@@ -17,12 +18,12 @@ services:
       bash -c 'bundle install && yarn install &&
       bin/rails server -b 0.0.0.0'
     networks:
-      - wca-main
+      - wca-registration
 
 volumes:
   gems_volume:
     driver: local
 
 networks:
-  wca-main:
-    name: wca-main
+  wca-registration:
+    name: wca-registration

--- a/dockerfile.dev
+++ b/dockerfile.dev
@@ -23,7 +23,3 @@ RUN apt-get update && apt-get install -y \
 
 
 RUN gem update --system && gem install bundler
-COPY . .
-RUN bundle install && yarn install
-
-CMD ["bin/rails", "server", "-b","0.0.0.0"]

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,0 +1,3 @@
+/.terraform/
+*.tfvars
+.terraform.lock.hcl

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,34 @@
+# Infrastructure
+
+The infrastructure for running the WCA Registration Service.
+
+## Setup
+
+First, install terraform and initialize with:
+
+```
+terraform init
+terraform workspace select prod || terraform workspace new prod
+```
+
+To apply changes run:
+
+```
+terraform apply
+```
+
+## Details
+
+The WCA Registration System runs on a single Docker container
+
+### App
+
+We use ECS to run the app container(s). Currently the service runs on one t3.small instance which can house up to two containers
+
+### Deployment
+
+To automate deployment we use a CodePipeline that is triggered by pushing a new app image to ECR. The pipeline:
+
+  1. Sources the new ECR image arn.
+  2. Prepares files necessary for CodeDeploy (`appspec.yaml`, `taskdef.json`)
+  3. Triggers CodeDeploy to do Blue/Green deployment.

--- a/infra/app.tf
+++ b/infra/app.tf
@@ -1,0 +1,411 @@
+resource "aws_security_group" "cluster" {
+  name        = "${var.name_prefix}-cluster"
+  description = "Production ECS cluster"
+  vpc_id      = aws_vpc.this.id
+
+  tags = {
+    Name = "${var.name_prefix}-cluster"
+  }
+}
+
+# Note: we use the standalone SG rules (rather than inline), because
+# cluster_cluster_ingress references the SG itself
+
+resource "aws_security_group_rule" "cluster_lb_ingress" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.cluster.id
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
+  source_security_group_id = aws_security_group.lb.id
+  description              = "Load balancer ingress"
+}
+
+resource "aws_security_group_rule" "cluster_cluster_ingress" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.cluster.id
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
+  source_security_group_id = aws_security_group.cluster.id
+  description              = "Allow ingress from other members of the cluster"
+}
+
+resource "aws_security_group_rule" "cluster_all_egress" {
+  type              = "egress"
+  security_group_id = aws_security_group.cluster.id
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "Allow all egress"
+}
+
+
+resource "aws_cloudwatch_log_group" "this" {
+  name = var.name_prefix
+}
+
+resource "aws_ecs_cluster" "this" {
+  name = var.name_prefix
+}
+
+locals {
+  app_environment = [
+    {
+      name  = "HOST"
+      value = "${var.host}"
+    },
+    {
+      name  = "WCA_HOST"
+      value = "${var.wca_host}"
+    }
+  ]
+}
+
+#resource "aws_ecs_task_definition" "migrate" {
+#  family = "${var.name_prefix}-migrate"
+#
+#  network_mode             = "awsvpc"
+#  requires_compatibilities = ["EC2"]
+#
+#  cpu    = 512
+#  memory = 512
+#
+#  container_definitions = jsonencode([
+#    {
+#      name         = "main"
+#      image        = "${aws_ecr_repository.this.repository_url}:latest"
+#      command      = ["/app/bin/migrate"]
+#      portMappings = []
+#      logConfiguration = {
+#        logDriver = "awslogs"
+#        options = {
+#          awslogs-group         = "${aws_cloudwatch_log_group.this.name}"
+#          awslogs-region        = "${var.region}"
+#          awslogs-stream-prefix = "${var.name_prefix}"
+#        }
+#      }
+#      environment = local.app_environment
+#    }
+#  ])
+#
+#  tags = {
+#    Name = "${var.name_prefix}-migrate"
+#  }
+#}
+
+data "aws_iam_policy_document" "task_assume_role_policy" {
+  statement {
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "task_execution_role" {
+  name               = "${var.name_prefix}-task-execution-role"
+  assume_role_policy = data.aws_iam_policy_document.task_assume_role_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution_role_attachment" {
+  role       = aws_iam_role.task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role" "task_role" {
+  name               = "${var.name_prefix}-task-role"
+  assume_role_policy = data.aws_iam_policy_document.task_assume_role_policy.json
+}
+
+data "aws_iam_policy_document" "task_policy" {
+  statement {
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "task_policy" {
+  role   = aws_iam_role.task_role.name
+  policy = data.aws_iam_policy_document.task_policy.json
+}
+
+resource "aws_ecs_task_definition" "main" {
+  family = var.name_prefix
+
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["EC2"]
+
+  # We configure the roles to allow `aws ecs execute-command` into a task,
+  # as in https://aws.amazon.com/blogs/containers/new-using-amazon-ecs-exec-access-your-containers-fargate-ec2
+  execution_role_arn = aws_iam_role.task_execution_role.arn
+  task_role_arn      = aws_iam_role.task_role.arn
+
+  cpu = "1024"
+  memory = "1024"
+
+  container_definitions = jsonencode([
+    {
+      name              = "main"
+      image             = "${aws_ecr_repository.this.repository_url}:latest"
+      cpu    = 1024
+      memory = 1024
+      portMappings = [
+        {
+          # The hostPort is automatically set for awsvpc network mode,
+          # see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PortMapping.html#ECS-Type-PortMapping-hostPort
+          containerPort = 3000
+          protocol      = "tcp"
+        },
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = "${aws_cloudwatch_log_group.this.name}"
+          awslogs-region        = "${var.region}"
+          awslogs-stream-prefix = "${var.name_prefix}"
+        }
+      }
+      environment = local.app_environment
+    }
+  ])
+
+  tags = {
+    Name = "${var.name_prefix}-main"
+  }
+}
+
+
+
+data "aws_ecs_task_definition" "main" {
+  task_definition = aws_ecs_task_definition.main.family
+}
+
+resource "aws_ecs_service" "main" {
+  name    = "${var.name_prefix}-main"
+  cluster = aws_ecs_cluster.this.id
+  # During deployment a new task revision is created with modified
+  # container image, so we want use data.aws_ecs_task_definition to
+  # always point to the active task definition
+  task_definition                    = data.aws_ecs_task_definition.main.arn
+  desired_count                      = 1
+  scheduling_strategy                = "REPLICA"
+  deployment_maximum_percent         = 200
+  deployment_minimum_healthy_percent = 50
+  health_check_grace_period_seconds  = 0
+
+  capacity_provider_strategy {
+    capacity_provider = aws_ecs_capacity_provider.this.name
+    weight            = 1
+  }
+
+  enable_execute_command = true
+
+  ordered_placement_strategy {
+    type  = "spread"
+    field = "attribute:ecs.availability-zone"
+  }
+
+  ordered_placement_strategy {
+    type  = "spread"
+    field = "instanceId"
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.this[0].arn
+    container_name   = "main"
+    container_port   = 3000
+  }
+
+  network_configuration {
+    security_groups = [aws_security_group.cluster.id]
+    subnets         = aws_subnet.private[*].id
+  }
+
+  deployment_controller {
+    type = "CODE_DEPLOY"
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-main"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      # The desired count is modified by Application Auto Scaling
+      desired_count,
+      # The target group changes during Blue/Green deployment
+      load_balancer,
+    ]
+  }
+
+  depends_on = [aws_lb_listener.https, aws_lb_listener.http]
+}
+
+resource "aws_appautoscaling_target" "this" {
+  service_namespace  = "ecs"
+  resource_id        = "service/${aws_ecs_cluster.this.name}/${aws_ecs_service.main.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  min_capacity       = 1
+  max_capacity       = 1
+}
+
+resource "aws_appautoscaling_policy" "this" {
+  name               = var.name_prefix
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.this.resource_id
+  scalable_dimension = aws_appautoscaling_target.this.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.this.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      # predefined_metric_type = "ECSServiceAverageCPUUtilization"
+      predefined_metric_type = "ECSServiceAverageMemoryUtilization"
+    }
+
+    # target_value = 80
+    target_value = 65
+  }
+
+  depends_on = [aws_appautoscaling_target.this]
+}
+
+data "aws_ami" "ecs" {
+  most_recent = true
+
+  owners = ["amazon"]
+
+  filter {
+    name   = "owner-alias"
+    values = ["amazon"]
+  }
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-ecs-hvm-*-x86_64-*"]
+  }
+}
+
+data "aws_iam_policy_document" "ecs_instance_assume_role_policy" {
+  statement {
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "ecs_instance_role" {
+  name               = "${var.name_prefix}-ecs-instance-role"
+  description        = "Allows ECS instances to call AWS services"
+  assume_role_policy = data.aws_iam_policy_document.ecs_instance_assume_role_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_instance_role_attachment" {
+  role       = aws_iam_role.ecs_instance_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_instance_profile" "ecs_instance_profile" {
+  name = "${var.name_prefix}-ecs-instance-profile"
+  role = aws_iam_role.ecs_instance_role.name
+}
+
+resource "aws_launch_configuration" "this" {
+  name_prefix          = "${var.name_prefix}-"
+  image_id             = data.aws_ami.ecs.id
+  iam_instance_profile = aws_iam_instance_profile.ecs_instance_profile.name
+  instance_type        = "t3.small"
+  security_groups      = [aws_security_group.cluster.id]
+  user_data            = templatefile("templates/user_data.sh.tftpl", { ecs_cluster_name = aws_ecs_cluster.this.name })
+
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_autoscaling_group" "this" {
+  name_prefix               = "${var.name_prefix}-"
+  min_size                  = 1
+  max_size                  = 1
+  desired_capacity          = 1
+  vpc_zone_identifier       = aws_subnet.private[*].id
+  launch_configuration      = aws_launch_configuration.this.name
+  health_check_grace_period = 0
+  health_check_type         = "EC2"
+  default_cooldown          = 300
+
+  # Necessary when using managed termination provider on capacity provider
+  protect_from_scale_in = true
+
+  # Note: this tag is automatically added when adding ECS Capacity Provider
+  # to the ASG and we need to reflect it in the config
+  tag {
+    key                 = "AmazonECSManaged"
+    value               = true
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Name"
+    value               = var.name_prefix
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Description"
+    value               = "Assigned to ${aws_ecs_cluster.this.name} ECS cluster, managed by ASG"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Env"
+    value               = var.env
+    propagate_at_launch = true
+  }
+
+  lifecycle {
+    create_before_destroy = true
+
+    # The desired count is modified by Application Auto Scaling
+    ignore_changes = [desired_capacity]
+  }
+}
+
+resource "aws_ecs_capacity_provider" "this" {
+  name = var.name_prefix
+
+  auto_scaling_group_provider {
+    auto_scaling_group_arn         = aws_autoscaling_group.this.arn
+    managed_termination_protection = "ENABLED"
+
+    managed_scaling {
+      maximum_scaling_step_size = 1
+      minimum_scaling_step_size = 1
+      status                    = "ENABLED"
+      target_capacity           = 100
+    }
+  }
+}
+
+resource "aws_ecs_cluster_capacity_providers" "this" {
+  cluster_name       = aws_ecs_cluster.this.name
+  capacity_providers = [aws_ecs_capacity_provider.this.name]
+
+  default_capacity_provider_strategy {
+    capacity_provider = aws_ecs_capacity_provider.this.name
+    weight            = 1
+  }
+}

--- a/infra/lb.tf
+++ b/infra/lb.tf
@@ -1,0 +1,136 @@
+resource "aws_security_group" "lb" {
+  name        = "${var.name_prefix}-load-balancer"
+  description = "Production load balancer"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow HTTP"
+  }
+
+  ingress {
+    from_port        = 80
+    to_port          = 80
+    protocol         = "tcp"
+    ipv6_cidr_blocks = ["::/0"]
+    description      = "Allow HTTP IPV6"
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow HTTPS"
+  }
+
+  ingress {
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    ipv6_cidr_blocks = ["::/0"]
+    description      = "Allow HTTPS IPV6"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all egress"
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-load-balancer"
+  }
+}
+
+resource "aws_lb" "this" {
+  name               = var.name_prefix
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = ["${aws_security_group.lb.id}"]
+  subnets            = aws_subnet.public[*].id
+  ip_address_type    = "ipv4"
+
+  # Note that we use WebSocket connections, but they send heartbeat every 30s
+  idle_timeout = 60
+}
+
+resource "aws_lb_target_group" "this" {
+  # Blue/Green
+  count = 2
+
+  name        = "${var.name_prefix}-${count.index}"
+  port        = 3000
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.this.id
+  target_type = "ip"
+
+  # WebSocket connections are long-lived, so we want to deregister
+  # the target more eagerly than the default 5 minutes
+  deregistration_delay = 30
+
+  health_check {
+    interval            = 10
+    path                = "/"
+    port                = "traffic-port"
+    protocol            = "HTTP"
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    matcher             = 200
+  }
+}
+
+data "aws_acm_certificate" "this" {
+  domain   = "*.worldcubeassociation.org"
+  statuses = ["ISSUED"]
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.this.arn
+
+  port            = 443
+  protocol        = "HTTPS"
+  ssl_policy      = "ELBSecurityPolicy-2016-08"
+  certificate_arn = data.aws_acm_certificate.this.arn
+
+  default_action {
+    target_group_arn = aws_lb_target_group.this[0].arn
+    type             = "forward"
+  }
+
+  lifecycle {
+    # The target group changes during Blue/Green deployment
+    ignore_changes = [default_action]
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-https"
+  }
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+
+  port     = 80
+  protocol = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-http"
+  }
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+
+  # Supports multiple workspaces
+  backend "s3" {
+    bucket = "wca-registration-terraform-state"
+    key    = "wca-registration"
+    region = "us-west-2"
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Env = var.env
+    }
+  }
+}

--- a/infra/pipeline.tf
+++ b/infra/pipeline.tf
@@ -1,0 +1,384 @@
+data "aws_iam_policy_document" "codepipeline_assume_role_policy" {
+  statement {
+    principals {
+      type        = "Service"
+      identifiers = ["codepipeline.amazonaws.com", "codebuild.amazonaws.com", "events.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "codepipeline_role" {
+  name               = "${var.name_prefix}-codepipeline-role"
+  description        = "The IAM role used by the pipeline"
+  assume_role_policy = data.aws_iam_policy_document.codepipeline_assume_role_policy.json
+}
+
+data "aws_iam_policy_document" "codepipeline_policy" {
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:PutObject",
+    ]
+
+    resources = [
+      aws_s3_bucket.this.arn,
+      "${aws_s3_bucket.this.arn}/*",
+    ]
+  }
+
+  statement {
+    actions   = ["ecr:DescribeImages"]
+    resources = [aws_ecr_repository.this.arn]
+  }
+
+  statement {
+    actions   = ["codebuild:BatchGetBuilds", "codebuild:StartBuild"]
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "ecs:DescribeTaskDefinition",
+      "ecs:DescribeTasks",
+      "ecs:RunTask",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "codedeploy:CreateDeployment",
+      "codedeploy:GetDeployment",
+      "codedeploy:GetApplication",
+      "codedeploy:GetApplicationRevision",
+      "codedeploy:RegisterApplicationRevision",
+      "codedeploy:GetDeploymentConfig",
+      "ecs:RegisterTaskDefinition",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    actions   = ["codepipeline:StartPipelineExecution"]
+    resources = [aws_codepipeline.this.arn]
+  }
+
+  statement {
+    actions   = ["iam:PassRole"]
+    resources = ["*"]
+    condition {
+      test     = "StringEqualsIfExists"
+      variable = "iam:PassedToService"
+
+      values = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "codepipeline_policy" {
+  role   = aws_iam_role.codepipeline_role.name
+  policy = data.aws_iam_policy_document.codepipeline_policy.json
+}
+
+#resource "aws_codebuild_project" "migrate" {
+#  name         = "${var.name_prefix}-migrate"
+#  service_role = aws_iam_role.codepipeline_role.arn
+#
+#  artifacts {
+#    type = "NO_ARTIFACTS"
+#  }
+#
+#  environment {
+#    compute_type                = "BUILD_GENERAL1_SMALL"
+#    type                        = "LINUX_CONTAINER"
+#    image                       = "aws/codebuild/standard:6.0"
+#    image_pull_credentials_type = "CODEBUILD"
+#  }
+#
+#  source {
+#    type = "NO_SOURCE"
+#    buildspec = templatefile("templates/buildspec_migrate.yml.tftpl", {
+#      ecs_cluster_name        = aws_ecs_cluster.this.name
+#      ecs_task_definition_arn = aws_ecs_task_definition.migrate.arn
+#      ecs_subnet_ids          = join(",", aws_subnet.private[*].id)
+#      ecs_security_groups     = aws_security_group.cluster.id
+#    })
+#  }
+#}
+
+resource "aws_codebuild_project" "build" {
+  name         = "${var.name_prefix}-build"
+  service_role = aws_iam_role.codepipeline_role.arn
+
+  artifacts {
+    type = "CODEPIPELINE"
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    type                        = "LINUX_CONTAINER"
+    image                       = "aws/codebuild/standard:6.0"
+    image_pull_credentials_type = "CODEBUILD"
+  }
+
+  source {
+    type = "CODEPIPELINE"
+    buildspec = templatefile("templates/buildspec_build.yml.tftpl", {
+      container_name         = "main"
+      container_port         = 3000
+      task_definition        = aws_ecs_task_definition.main.arn
+      capacity_provider_name = aws_ecs_capacity_provider.this.name
+    })
+  }
+}
+
+data "aws_iam_policy_document" "codedeploy_assume_role_policy" {
+  statement {
+    principals {
+      type        = "Service"
+      identifiers = ["codedeploy.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "codedeploy_role" {
+  name               = "${var.name_prefix}-codedeploy-role"
+  assume_role_policy = data.aws_iam_policy_document.codedeploy_assume_role_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "codedeploy_role_attachment" {
+  role       = aws_iam_role.codedeploy_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS"
+}
+
+resource "aws_codedeploy_app" "this" {
+  name             = var.name_prefix
+  compute_platform = "ECS"
+}
+
+resource "aws_codedeploy_deployment_group" "this" {
+  app_name               = aws_codedeploy_app.this.name
+  deployment_group_name  = var.name_prefix
+  deployment_config_name = "CodeDeployDefault.ECSAllAtOnce"
+  service_role_arn       = aws_iam_role.codedeploy_role.arn
+
+  blue_green_deployment_config {
+    deployment_ready_option {
+      action_on_timeout = "CONTINUE_DEPLOYMENT"
+    }
+
+    terminate_blue_instances_on_deployment_success {
+      action                           = "TERMINATE"
+      termination_wait_time_in_minutes = 5
+    }
+  }
+
+  deployment_style {
+    deployment_type   = "BLUE_GREEN"
+    deployment_option = "WITH_TRAFFIC_CONTROL"
+  }
+
+  auto_rollback_configuration {
+    enabled = true
+    events  = ["DEPLOYMENT_FAILURE"]
+  }
+
+  ecs_service {
+    cluster_name = aws_ecs_cluster.this.name
+    service_name = aws_ecs_service.main.name
+  }
+
+  load_balancer_info {
+    target_group_pair_info {
+      prod_traffic_route {
+        listener_arns = [aws_lb_listener.https.arn]
+      }
+
+      target_group {
+        name = aws_lb_target_group.this[0].name
+      }
+
+      target_group {
+        name = aws_lb_target_group.this[1].name
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket" "this" {
+  bucket        = var.name_prefix
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    id = "rule-1"
+
+    filter {}
+
+    expiration {
+      days = 30
+    }
+
+    status = "Enabled"
+  }
+}
+
+resource "aws_ecr_repository" "this" {
+  name         = var.name_prefix
+  force_delete = true
+}
+
+resource "aws_ecr_lifecycle_policy" "this" {
+  repository = aws_ecr_repository.this.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Expire images older than 14 days"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 14
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_codepipeline" "this" {
+  name     = var.name_prefix
+  role_arn = aws_iam_role.codepipeline_role.arn
+
+  artifact_store {
+    type     = "S3"
+    location = aws_s3_bucket.this.bucket
+  }
+
+  stage {
+    name = "source"
+
+    action {
+      name             = "source"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "ECR"
+      version          = "1"
+      output_artifacts = ["image"]
+
+      configuration = {
+        RepositoryName = aws_ecr_repository.this.name
+        ImageTag       = "latest"
+      }
+    }
+  }
+
+  stage {
+    name = "build"
+
+    action {
+      name     = "build"
+      category = "Build"
+      owner    = "AWS"
+      provider = "CodeBuild"
+      version  = "1"
+
+      input_artifacts  = ["image"]
+      output_artifacts = ["build_output"]
+
+      configuration = {
+        ProjectName = aws_codebuild_project.build.name
+      }
+    }
+  }
+# At the Moment we don't need a migrate stage
+#  stage {
+#    name = "migrate"
+#
+#    action {
+#      name     = "migrate"
+#      category = "Build"
+#      owner    = "AWS"
+#      provider = "CodeBuild"
+#      version  = "1"
+#
+#      input_artifacts = ["image"]
+#
+#      configuration = {
+#        ProjectName = aws_codebuild_project.migrate.name
+#      }
+#    }
+#  }
+
+  stage {
+    name = "deploy"
+
+    action {
+      name     = "deploy"
+      category = "Deploy"
+      owner    = "AWS"
+      provider = "CodeDeployToECS"
+      version  = "1"
+
+      input_artifacts = ["build_output"]
+
+      configuration = {
+        ApplicationName                = aws_codedeploy_app.this.name
+        DeploymentGroupName            = aws_codedeploy_deployment_group.this.deployment_group_name
+        TaskDefinitionTemplateArtifact = "build_output"
+        TaskDefinitionTemplatePath     = "taskdef.json"
+        AppSpecTemplateArtifact        = "build_output"
+        AppSpecTemplatePath            = "appspec.yaml"
+        Image1ArtifactName             = "build_output"
+        Image1ContainerName            = "IMAGE_NAME"
+      }
+    }
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "ecr_image_push" {
+  name     = "${var.name_prefix}-ecr-image-push"
+  role_arn = aws_iam_role.codepipeline_role.arn
+
+  event_pattern = jsonencode({
+    source      = ["aws.ecr"]
+    detail-type = ["ECR Image Action"]
+
+    detail = {
+      repository-name = [aws_ecr_repository.this.name]
+      image-tag       = ["latest"]
+      action-type     = ["PUSH"]
+      result          = ["SUCCESS"]
+    }
+  })
+}
+#
+#resource "aws_cloudwatch_event_target" "ecr_image_push" {
+#  rule     = aws_cloudwatch_event_rule.ecr_image_push.name
+#  arn      = aws_codepipeline.this.arn
+#  role_arn = aws_iam_role.codepipeline_role.arn
+#}

--- a/infra/templates/buildspec_build.yml.tftpl
+++ b/infra/templates/buildspec_build.yml.tftpl
@@ -1,0 +1,18 @@
+version: 0.2
+
+phases:
+  build:
+    commands:
+      # Note that we explicitly specify CapacityProviderStrategy in the appspec,
+      # otherwise the deployment switches the service to launch type EC2.
+      # See https://github.com/aws/containers-roadmap/issues/1752
+      - "printf 'version: 0.0\nResources:\n  - TargetService:\n      Type: AWS::ECS::Service\n      Properties:\n        TaskDefinition: <TASK_DEFINITION>\n        LoadBalancerInfo:\n          ContainerName: \"${container_name}\"\n          ContainerPort: ${container_port}\n        CapacityProviderStrategy:\n          - CapacityProvider: \"${capacity_provider_name}\"\n            Weight: 1' > appspec.yaml"
+      - aws ecs describe-task-definition --output json --task-definition ${task_definition} --query taskDefinition > task_definition.json
+      - jq '.containerDefinitions | map((select(.name == "${container_name}") | .image) |= "<IMAGE_NAME>") | {"containerDefinitions":.}' task_definition.json > task_definition_patch.json
+      - jq -s '.[0] * .[1]' task_definition.json task_definition_patch.json > taskdef.json
+
+artifacts:
+  files:
+    - imageDetail.json
+    - appspec.yaml
+    - taskdef.json

--- a/infra/templates/buildspec_migrate.yml.tftpl
+++ b/infra/templates/buildspec_migrate.yml.tftpl
@@ -1,0 +1,13 @@
+version: 0.2
+
+phases:
+  build:
+    commands:
+      - run_result=$(aws ecs run-task --cluster ${ecs_cluster_name} --task-definition ${ecs_task_definition_arn} --network-configuration "awsvpcConfiguration={subnets=[${ecs_subnet_ids}],securityGroups=[${ecs_security_groups}]}")
+      - echo "$run_result"
+      - container_arn=$(echo $run_result | jq '.tasks[0].taskArn' | sed -e 's/^"//' -e 's/"$//')
+      - aws ecs wait tasks-stopped --cluster ${ecs_cluster_name} --tasks "$container_arn"
+      - describe_result=$(aws ecs describe-tasks --cluster ${ecs_cluster_name} --tasks "$container_arn")
+      - terminated_status=$(echo "$describe_result" | jq '.tasks[0].containers[0].exitCode')
+      - echo $terminated_status
+      - exit $terminated_status

--- a/infra/templates/user_data.sh.tftpl
+++ b/infra/templates/user_data.sh.tftpl
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "ECS_CLUSTER=${ecs_cluster_name}" >> /etc/ecs/ecs.config

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,61 @@
+variable "env" {
+  type        = string
+  description = "Environment name"
+  default     = "prod"
+}
+
+variable "name_prefix" {
+  type        = string
+  description = "Prefix for naming resources"
+  default     = "wca-registration"
+}
+
+variable "region" {
+  type        = string
+  description = "The region to operate in"
+  default     = "us-west-2"
+}
+
+variable "availability_zones" {
+  type        = list(string)
+  description = "Availability zones"
+  default     = ["us-west-2a", "us-west-2b"]
+}
+
+#variable "secret_key_base" {
+#  type        = string
+#  description = "The secret key base for the application"
+#  sensitive   = true
+#}
+
+# PoC will deploy without a external DB
+#variable "db_username" {
+#  type        = string
+#  description = "Username for the database"
+#  sensitive   = true
+#}
+#
+#variable "db_password" {
+#  type        = string
+#  description = "Password for the database"
+#  sensitive   = true
+#}
+#
+#variable "db_name" {
+#  type        = string
+#  description = "Name of the database"
+#  sensitive   = true
+#}
+
+variable "host" {
+  type        = string
+  description = "The host for generating absolute URLs in the application"
+  default     = "register.worldcubeassociation.org"
+}
+
+variable "wca_host" {
+  type        = string
+  description = "The host for generating absolute URLs in the application"
+  default     = "worldcubeassociation.org"
+}
+

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -1,0 +1,99 @@
+resource "aws_vpc" "this" {
+  cidr_block = "10.0.0.0/16"
+
+  # Both of these need to be enabled in order to use DNS domain names
+  # in defined a private hosted zone (which we use for node discovery)
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = var.name_prefix
+  }
+}
+
+resource "aws_subnet" "public" {
+  count = length(var.availability_zones)
+
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = "10.0.${1 + count.index}.0/24"
+  availability_zone = element(var.availability_zones, count.index)
+
+  tags = {
+    Name = "${var.name_prefix}-public-${count.index + 1}"
+  }
+}
+
+resource "aws_subnet" "private" {
+  count = length(var.availability_zones)
+
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = "10.0.${101 + count.index}.0/24"
+  availability_zone = element(var.availability_zones, count.index)
+
+  tags = {
+    Name = "${var.name_prefix}-private-${count.index + 1}"
+  }
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = {
+    Name = var.name_prefix
+  }
+}
+
+resource "aws_eip" "nat_gateway" {
+  vpc = true
+
+  tags = {
+    Name = "${var.name_prefix}-nat-gateway"
+  }
+}
+
+resource "aws_nat_gateway" "this" {
+  allocation_id = aws_eip.nat_gateway.id
+  subnet_id     = aws_subnet.public[0].id
+
+  tags = {
+    Name = var.name_prefix
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-public"
+  }
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.this.id
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-private"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(aws_subnet.public)
+  subnet_id      = element(aws_subnet.public[*].id, count.index)
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "private" {
+  count          = length(aws_subnet.private)
+  subnet_id      = element(aws_subnet.private[*].id, count.index)
+  route_table_id = aws_route_table.private.id
+}


### PR DESCRIPTION
This creates a bunch of infrastructure to deploy the registration service including
- A VPC to house all the infrastructure
- An ECS cluster to manage container placement
- A EC2 instance acting as the host for the container
- A Load Balancer to route the traffic to the cluster
- A Codepipeline to manage deployment on image push

I basically stole it all from [Jonatan's deployment of WCA Live](https://github.com/thewca/wca-live/tree/main/infra) with a few things removed that I didn't need. 

I have ran this through and you can now access the service on https://registration.worldcubeassociation.org/ (you just get an error but that is intentional)

Included is a deployment action also taken from wca-live which builds the image and pushes it to the Amazon Elastic Container Registry which in turn triggers the Code Pipeline

Closes #3 