### PR TITLE
Add healthcheck route

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ under development. For more info about the WCA visit the main repo [here](https:
 
 ## How to run
 
-Run  `docker compose up`
+Run  `docker compose -f docker-compose.dev.yml up`

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,6 +2,12 @@ require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+  config.hosts << "registration.worldcubeassociation.org"
+
+  # Exclude requests for the /healthcheck/ path from host checking
+  Rails.application.config.host_authorization = {
+    exclude: ->(request) { request.path =~ /healthcheck/ }
+  }
 
   # Code is not reloaded between requests.
   config.cache_classes = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,3 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Defines the root path route ("/")
-  # root "articles#index"
+  get '/healthcheck', to: 'healthcheck#index'
 end

--- a/dockerfile
+++ b/dockerfile
@@ -24,6 +24,10 @@ RUN apt-get update && apt-get install -y \
 
 RUN gem update --system && gem install bundler
 COPY . .
-RUN bundle install && yarn install
 
-CMD ["bin/rails", "server", "-b","0.0.0.0"]
+ENV RAILS_ENV production
+
+RUN bundle install --without development test  # Install production gems
+RUN yarn install --production  # Install production Node.js packages
+
+CMD ["bin/rails", "server", "-e", "production", "-b", "0.0.0.0"]

--- a/infra/lb.tf
+++ b/infra/lb.tf
@@ -76,7 +76,7 @@ resource "aws_lb_target_group" "this" {
 
   health_check {
     interval            = 10
-    path                = "/"
+    path                = "/healthcheck"
     port                = "traffic-port"
     protocol            = "HTTP"
     timeout             = 5

--- a/infra/pipeline.tf
+++ b/infra/pipeline.tf
@@ -376,9 +376,9 @@ resource "aws_cloudwatch_event_rule" "ecr_image_push" {
     }
   })
 }
-#
-#resource "aws_cloudwatch_event_target" "ecr_image_push" {
-#  rule     = aws_cloudwatch_event_rule.ecr_image_push.name
-#  arn      = aws_codepipeline.this.arn
-#  role_arn = aws_iam_role.codepipeline_role.arn
-#}
+
+resource "aws_cloudwatch_event_target" "ecr_image_push" {
+  rule     = aws_cloudwatch_event_rule.ecr_image_push.name
+  arn      = aws_codepipeline.this.arn
+  role_arn = aws_iam_role.codepipeline_role.arn
+}


### PR DESCRIPTION
Added a /healthcheck path which is useful full deployment and scaling.  
I also used this change to test the pipeline and everything worked (after tweaking the memory values down a bit). Seems to take about 10 minutes, but half of that is just waiting in case we want to abort the deployment if there are some issues. 

Closes #27 