### PR TITLE
Add dummy routes for /register and /registrations

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+.git
+.github
+tmp/*
+log/*
+infra
+storage/*
+docker-compose.dev.yml
+dockerfile.dev

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,9 @@ gem "jbuilder"
 gem "redis", "~> 4.0"
 gem 'hiredis'
 
+# DynamoDB for storing registrations
+gem 'aws-sdk-dynamodb'
+
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 gem "kredis"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,18 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.762.0)
+    aws-sdk-core (3.172.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.5)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-dynamodb (1.84.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.5.2)
+      aws-eventstream (~> 1, >= 1.0.2)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
@@ -87,6 +99,7 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jmespath (1.6.2)
     kredis (1.3.0.1)
       activesupport (>= 6.0.0)
       redis (>= 4.2, < 6)
@@ -167,6 +180,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  aws-sdk-dynamodb
   bootsnap
   debug
   hiredis

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,0 +1,5 @@
+class HealthcheckController < ApplicationController
+  def index
+    render json: { status: "ok" }, status: :ok
+  end
+end

--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -1,0 +1,63 @@
+require 'securerandom'
+class RegistrationController < ApplicationController
+  def create
+    competitor_id = params[:competitor_id]
+    competition_id = params[:competition_id]
+    event_ids = params[:event_ids]
+
+    unless user_can_register(competitor_id, competition_id)
+      return render json: { status: 'User cannot register, wrong format' }, status: :forbidden
+    end
+
+    registration = {
+      id: SecureRandom.uuid,
+      competitor_id: competitor_id,
+      competition_id: competition_id,
+      registration_data: {
+        event_ids: event_ids
+      }
+    }
+
+    $dynamodb.put_item({
+       table_name: 'Registrations',
+       item: registration
+    })
+
+    render json: { status: 'ok' }
+  end
+
+  def list
+    competition_id = params[:competition_id]
+    registrations = get_registrations(competition_id)
+
+    render json: registrations
+  end
+
+  private
+
+  def user_can_register(competitor_id, competition_id)
+    # check that competitor ID is in the correct format
+    if competitor_id =~ /^\d{4}[a-zA-Z]{4}\d{2}$/
+      # check that competition ID is in the correct format
+      if competition_id =~ /^[a-zA-Z]+\d{4}$/
+        return true
+      end
+    end
+    false
+  end
+
+
+
+  def get_registrations(competition_id)
+    # Query DynamoDB for registrations with the given competition_id
+    resp = $dynamodb.query({
+      table_name: 'Registrations',
+      key_condition_expression: '#ci = :cid',
+      expression_attribute_names: { '#ci' => 'competition_id' },
+      expression_attribute_values: { ':cid' => competition_id }
+    })
+
+    # Return the items from the response
+    resp.items
+  end
+end

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,0 +1,14 @@
+# config/initializers/aws.rb
+
+if Rails.env.production?
+  # We are using IAM Roles to authenticate in prod
+  Aws.config.update({
+    region: ENV["AWS_REGION"],
+  })
+  $dynamodb = Aws::DynamoDB::Client.new
+else
+  # We are using fake values in dev
+  $dynamodb = Aws::DynamoDB::Client.new(endpoint: ENV['DYNAMODB_ENDPOINT'], region: "my-cool-region-1", credentials: Aws::Credentials.new('my_cool_key', 'my_cool_secret'))
+end
+
+

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,25 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-Rails.application.config.middleware.insert_before 0, Rack::Cors do
-  allow do
-    origins "*.worldcubeassociation.org"
+if Rails.env.development? || Rails.env.test?
+  Rails.application.config.middleware.insert_before 0, Rack::Cors do
+    allow do
+      origins "*"
 
-    resource "*",
-      headers: :any,
-      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+      resource "*",
+               headers: :any,
+               methods: [:get, :post, :put, :patch, :delete, :options, :head]
+    end
+  end
+
+else
+  Rails.application.config.middleware.insert_before 0, Rack::Cors do
+    allow do
+      origins "*.worldcubeassociation.org", "http://test.registration.worldcubeassociation.org.s3-website-us-west-2.amazonaws.com"
+
+      resource "*",
+               headers: :any,
+               methods: [:get, :post, :put, :patch, :delete, :options, :head]
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
   get '/healthcheck', to: 'healthcheck#index'
+  post '/register', to: 'registration#create'
+  get '/registrations', to: 'registration#list'
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,19 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)
+table_name = 'Registrations'
+key_schema = [
+  { attribute_name: 'competition_id', key_type: 'HASH' },
+  { attribute_name: 'competitor_id', key_type: 'RANGE' }
+]
+attribute_definitions = [
+  { attribute_name: 'competition_id', attribute_type: 'S' },
+  { attribute_name: 'competitor_id', attribute_type: 'S' }
+]
+provisioned_throughput = {
+  read_capacity_units: 5,
+  write_capacity_units: 5
+}
+$dynamodb.create_table({
+ table_name: table_name,
+ key_schema: key_schema,
+ attribute_definitions: attribute_definitions,
+ provisioned_throughput: provisioned_throughput
+})

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "3001:3000"
     environment:
-      WCA_MAIN: test
+      DYNAMODB_ENDPOINT: "http://dynamodb-local:8000"
     volumes:
       - .:/app
       - gems_volume:/usr/local/bundle
@@ -15,10 +15,32 @@ services:
     # First, install Ruby and Node dependencies
     # Start the server and bind to 0.0.0.0 (vs 127.0.0.1) so Docker's port mappings work correctly
     command: >
-      bash -c 'bundle install && yarn install &&
+      bash -c 'bundle install && yarn install && bin/rake db:seed &&
       bin/rails server -b 0.0.0.0'
     networks:
       - wca-registration
+    depends_on:
+      - dynamodb-local
+
+  dynamodb-local:
+    image: amazon/dynamodb-local:latest
+    container_name: dynamodb-local
+    ports:
+      - "8000:8000"
+    networks:
+      - wca-registration
+
+  dynamodb-admin:
+    image: aaronshaf/dynamodb-admin
+    ports:
+      - "8001:8001"
+    environment:
+      DYNAMO_ENDPOINT: "http://dynamodb-local:8000"
+      AWS_REGION: "us-west-2"
+      AWS_ACCESS_KEY_ID: local
+      AWS_SECRET_ACCESS_KEY: local
+    depends_on:
+      - dynamodb-local
 
 volumes:
   gems_volume:

--- a/infra/app.tf
+++ b/infra/app.tf
@@ -54,11 +54,15 @@ locals {
   app_environment = [
     {
       name  = "HOST"
-      value = "${var.host}"
+      value = var.host
     },
     {
       name  = "WCA_HOST"
-      value = "${var.wca_host}"
+      value = var.wca_host
+    },
+    {
+      name = "AWS_REGION"
+      value = var.region
     }
   ]
 }
@@ -131,6 +135,17 @@ data "aws_iam_policy_document" "task_policy" {
     ]
 
     resources = ["*"]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "dynamodb:PutItem",
+      "dynamodb:GetItem",
+      "dynamodb:Query",
+      "dynamodb:UpdateItem",
+      "dynamodb:DeleteItem",
+    ]
+    resources = [aws_dynamodb_table.registrations.arn]
   }
 }
 

--- a/infra/dynamodb.tf
+++ b/infra/dynamodb.tf
@@ -1,0 +1,22 @@
+resource "aws_dynamodb_table" "registrations" {
+  name           = "Registrations"
+  billing_mode   = "PROVISIONED"
+  read_capacity  = 5
+  write_capacity = 5
+  hash_key = "competition_id"
+  range_key = "competitor_id"
+
+  attribute {
+    name = "competition_id"
+    type = "S"
+  }
+
+  attribute {
+    name = "competitor_id"
+    type = "S"
+  }
+  ttl {
+    attribute_name = "TimeToExist"
+    enabled        = false
+  }
+}

--- a/test/controllers/healthcheck_controller_test.rb
+++ b/test/controllers/healthcheck_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class HealthcheckControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/registration_controller_test.rb
+++ b/test/controllers/registration_controller_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class RegistrationsControllerTest < ActionDispatch::IntegrationTest
+  test 'should create registration' do
+    $dynamodb.stub_responses(:put_item, {})
+
+    post '/register', params: {
+      competitor_id: '123',
+      competition_id: '456',
+      event_ids: ['333', '444']
+    }
+
+    assert_response :success
+  end
+end

--- a/test/controllers/registration_controller_test.rb
+++ b/test/controllers/registration_controller_test.rb
@@ -5,8 +5,8 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
     $dynamodb.stub_responses(:put_item, {})
 
     post '/register', params: {
-      competitor_id: '123',
-      competition_id: '456',
+      competitor_id: '2003BRUC01',
+      competition_id: 'Worlds2003',
       event_ids: ['333', '444']
     }
 


### PR DESCRIPTION
Creates Two Dummy routes:
- /register:  does very basic validation for WCA id and Competition id and inserts them into the database
- /registration: load registrations from the database by competition_id

The database used is a DynamoDB Table with the schema
id : uuid
competition_id: string
competitor_id: string
registration_data: json object

The keys for the Table are competition_id (hash key) and competitor_id (range key). 

Locally, the database is simulated using the official dynamodb-local image and I added the dynamodb-admin image to look into the DB if needed.

I also created http://test.registration.worldcubeassociation.org.s3-website-us-west-2.amazonaws.com/ for some simple frontend testing 