### PR TITLE
Change Staging to run as ECS Service

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -39,7 +39,6 @@ jobs:
         if: steps.trigger-deployment.outputs.triggered == 'true'
         env:
           CLUSTER_NAME: wca-registration-staging
-          TASK_DEFINITION: arn:aws:ecs:us-west-2:285938427530:task-definition/wca-registration-staging
         run: |
           docker build -f dockerfile.handler -t wca-registration-handler .
           docker build -f dockerfile.worker -t wca-registration-worker .
@@ -47,4 +46,4 @@ jobs:
           docker tag wca-registration-worker:latest ${{ steps.login-ecr.outputs.registry }}/wca-registration-worker:staging
           docker push ${{ steps.login-ecr.outputs.registry }}/wca-registration-handler:staging
           docker push ${{ steps.login-ecr.outputs.registry }}/wca-registration-worker:staging
-          aws ecs run-task --cluster ${{ env.CLUSTER_NAME }} --launch-type FARGATE --task-definition ${{ env.TASK_DEFINITION }} --network-configuration "awsvpcConfiguration={subnets=[subnet-07a07ca6717f0b354],securityGroups=[sg-088e90f450324203b]}"
+          aws ecs update-service --cluster ${{ env.CLUSTER_NAME }} --service Staging-Service --force-new-deployment --desired-count 1

--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -24,15 +24,14 @@ class RegistrationController < ApplicationController
       registration_status: 'waiting',
       step: 'Event Registration',
     }
-    queue_url = $sqs.get_queue_url(queue_name: 'registrations.fifo').queue_url
-    @queue ||= Aws::SQS::Queue.new(queue_url)
+    queue_url = ENV["QUEUE_URL"] || @sqs.get_queue_url(queue_name: 'registrations.fifo').queue_url
 
-    @queue.send_message({
-                          queue_url: queue_url,
-                          message_body: step_data.to_json,
-                          message_group_id: id,
-                          message_deduplication_id: id,
-                        })
+    $sqs.send_message({
+                        queue_url: queue_url,
+                        message_body: step_data.to_json,
+                        message_group_id: id,
+                        message_deduplication_id: id,
+                      })
 
     render json: { status: 'ok', message: 'Started Registration Process' }
   end

--- a/app/worker/queue_poller.rb
+++ b/app/worker/queue_poller.rb
@@ -16,8 +16,8 @@ class QueuePoller
   def self.perform
     PrometheusExporter::Client.default = PrometheusExporter::Client.new(host: ENV.fetch("PROMETHEUS_EXPORTER"), port: 9091)
     # Instrumentation of the worker process is currently disabled per https://github.com/discourse/prometheus_exporter/issues/282
-    if ENV.fetch("ENVIRONMENT", "dev") == "staging"
-      PrometheusExporter::Instrumentation::Process.start(type: "wca-registration-worker-staging", labels: { process: "1" })
+    if ENV.fetch("CODE_ENVIRONMENT", "dev") == "staging"
+      # PrometheusExporter::Instrumentation::Process.start(type: "wca-registration-worker-staging", labels: { process: "1" })
       @suffix = "-staging"
     else
       # PrometheusExporter::Instrumentation::Process.start(type: "wca-registration-worker", labels: { process: "1" })
@@ -31,9 +31,8 @@ class QueuePoller
              else
                Aws::SQS::Client.new
              end
-
-    queue = @sqs.get_queue_url(queue_name: 'registrations.fifo').queue_url
-    poller = Aws::SQS::QueuePoller.new(queue)
+    queue_url = ENV["QUEUE_URL"] || @sqs.get_queue_url(queue_name: 'registrations.fifo').queue_url
+    poller = Aws::SQS::QueuePoller.new(queue_url)
     poller.poll(wait_time_seconds: WAIT_TIME, max_number_of_messages: MAX_MESSAGES) do |messages|
       messages.each do |msg|
         # Messages are deleted from the queue when the block returns normally!

--- a/config/initializers/_vault.rb
+++ b/config/initializers/_vault.rb
@@ -15,7 +15,7 @@ Vault.configure do |vault|
   # prefixed with this application name. If you change the name of the
   # application, you will need to migrate the encrypted data to the new
   # key namespace. Default: ENV["VAULT_RAILS_APPLICATION"].
-  env = ENV.fetch("ENVIRONMENT", "development")
+  env = ENV.fetch("CODE_ENVIRONMENT", "development")
   if env == "production"
     @vault_application = "wca-registration"
   elsif env == "staging"

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -8,7 +8,7 @@ require_relative '../../app/helpers/metrics'
 
 PrometheusExporter::Client.default = PrometheusExporter::Client.new(host: ENV.fetch("PROMETHEUS_EXPORTER"), port: 9091)
 
-if ENV.fetch("ENVIRONMENT", "dev") == "staging"
+if ENV.fetch("CODE_ENVIRONMENT", "dev") == "staging"
   PrometheusExporter::Instrumentation::Process.start(type: "wca-registration-handler-staging", labels: { process: "1" })
   @suffix = "-staging"
 else

--- a/infra/handler/main.tf
+++ b/infra/handler/main.tf
@@ -25,8 +25,12 @@ locals {
       value = aws_iam_role.task_role.name
     },
     {
-      name = "ENVIRONMENT"
+      name = "CODE_ENVIRONMENT"
       value = "production"
+    },
+    {
+      name = "QUEUE_URL",
+      value = var.shared_resources.queue.url
     },
     {
       name = "PROMETHEUS_EXPORTER"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -51,4 +51,8 @@ module "staging" {
 
   registration-handler-ecr-repository = module.handler.ecr_repository_url
   registration-worker-ecr-repository = module.worker.ecr_repository_url
+  private_subnets = module.shared_resources.private_subnets
+  vpc_id = module.shared_resources.vpc_id
+  cluster_security_id = module.shared_resources.cluster_security.id
+  depends_on = [module.shared_resources]
 }

--- a/infra/staging/ecs.tf
+++ b/infra/staging/ecs.tf
@@ -4,3 +4,39 @@ resource "aws_ecs_cluster" "this" {
     Env = "staging"
   }
 }
+
+resource "aws_ecs_service" "this" {
+  name    = "Staging-Service"
+  cluster = aws_ecs_cluster.this.id
+  task_definition                    = data.aws_ecs_task_definition.this.arn
+  desired_count                      = 1
+  scheduling_strategy                = "REPLICA"
+  deployment_maximum_percent         = 200
+  deployment_minimum_healthy_percent = 50
+  health_check_grace_period_seconds  = 0
+  launch_type = "FARGATE"
+  enable_execute_command = true
+
+  network_configuration {
+    security_groups = [var.cluster_security_id]
+    subnets         = var.private_subnets
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.this.arn
+    container_name   = "staging-handler"
+    container_port   = 3000
+  }
+
+  deployment_controller {
+    type = "ECS"
+  }
+
+  tags = {
+    Name = var.name_prefix
+    Env = "staging"
+  }
+  lifecycle {
+    ignore_changes = [task_definition, desired_count]
+  }
+}

--- a/infra/staging/lambda/index.js
+++ b/infra/staging/lambda/index.js
@@ -1,4 +1,4 @@
-const { ECSClient, ListTasksCommand, DescribeTasksCommand, StopTaskCommand } = require("@aws-sdk/client-ecs");
+const { ECSClient, ListTasksCommand, DescribeTasksCommand, StopTaskCommand, UpdateServiceCommand } = require("@aws-sdk/client-ecs");
 
 const ecs = new ECSClient();
 
@@ -33,6 +33,16 @@ exports.handler = async (event, context) => {
                 const stopTaskCommand = new StopTaskCommand(stopTaskParams);
                 await ecs.send(stopTaskCommand);
                 console.log(`Terminated task: ${taskArn}`);
+
+                const updateServiceParams = {
+                    cluster: clusterName,
+                    service: "Staging-Service",
+                    desiredCount: 0
+                };
+
+                const updateServiceCommand = new UpdateServiceCommand(updateServiceParams);
+                await ecs.send(updateServiceCommand);
+                console.log(`Updated service: ${task.serviceArn} to set desired task count to 0`);
             }
         }
 

--- a/infra/staging/variables.tf
+++ b/infra/staging/variables.tf
@@ -49,3 +49,18 @@ variable "registration-worker-ecr-repository" {
   type = string
   description = "The Repository for the Worker"
 }
+
+variable "vpc_id" {
+  type = string
+  description = "The VPC of the service"
+}
+
+variable "private_subnets" {
+  type = any
+  description = "A list of private subnets of the service"
+}
+
+variable "cluster_security_id" {
+  type = string
+  description = "The security group of the cluster"
+}

--- a/infra/worker/main.tf
+++ b/infra/worker/main.tf
@@ -17,7 +17,7 @@ locals {
       value = var.shared_resources.queue.url
     },
     {
-      name = "ENVIRONMENT"
+      name = "CODE_ENVIRONMENT"
       value = "production"
     },
     {


### PR DESCRIPTION
This PR changes the staging Environment to run as a Service instead of a standalone task, which means that it will not just die if it becomes unhealthy, but stay up for us to look into the logs to see what went wrong. 

Using that power I also unearthed a lot of configuration that I forgot to change to make staging work. This PR also fixes those. Staging Containers now successfully deploy as a service