### PR TITLE
Add Rubyprof Profiling Around Action

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,4 +65,5 @@ end
 group :development do
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
+  gem "ruby-prof"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.15.2-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.15.2-x86_64-linux)
       racc (~> 1.4)
     parallel (1.23.0)
@@ -237,7 +239,9 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
+    ruby-prof (1.6.3)
     ruby-progressbar (1.13.0)
+    sqlite3 (1.6.3-aarch64-linux)
     sqlite3 (1.6.3-x86_64-linux)
     thor (1.2.2)
     timeout (0.3.2)
@@ -260,6 +264,7 @@ GEM
     zeitwerk (2.6.8)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES
@@ -279,6 +284,7 @@ DEPENDENCIES
   rspec-rails
   rswag
   rubocop
+  ruby-prof
   sqlite3 (~> 1.4)
   tzinfo-data
   vault-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,11 +3,11 @@
 class ApplicationController < ActionController::API
   around_action :performance_profile if Rails.env == 'development'
 
-  def performance_profile
-    if params[:profile] && (result = RubyProf.profile { yield })
+  def performance_profile(&)
+    if params[:profile] && (result = RubyProf.profile(&))
 
       out = StringIO.new
-      RubyProf::GraphHtmlPrinter.new(result).print out, :min_percent => 0
+      RubyProf::GraphHtmlPrinter.new(result).print out, min_percent: 0
       response.set_header("Content-Type", "text/html")
       response.body = out.string
     else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,12 +4,12 @@ class ApplicationController < ActionController::API
   around_action :performance_profile if Rails.env == 'development'
 
   def performance_profile
-    if params[:profile] && result = RubyProf.profile { yield }
+    if params[:profile] && (result = RubyProf.profile { yield })
 
       out = StringIO.new
       RubyProf::GraphHtmlPrinter.new(result).print out, :min_percent => 0
-      self.response_body = out.string
-
+      response.set_header("Content-Type", "text/html")
+      response.body = out.string
     else
       yield
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,17 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::API
+  around_action :performance_profile if Rails.env == 'development'
+
+  def performance_profile
+    if params[:profile] && result = RubyProf.profile { yield }
+
+      out = StringIO.new
+      RubyProf::GraphHtmlPrinter.new(result).print out, :min_percent => 0
+      self.response_body = out.string
+
+    else
+      yield
+    end
+  end
 end


### PR DESCRIPTION
This PR adds profiling as an around action in the development environment so you can run get Rubyprof profile data for each action. 
This should help us find out why some of the routes are becoming slow