### PR TITLE
Add Validations to Create and Update

### DIFF
--- a/app/helpers/competition_api.rb
+++ b/app/helpers/competition_api.rb
@@ -5,16 +5,30 @@ require 'net/http'
 require 'json'
 
 class CompetitionApi
-  def self.check_competition(competition_id)
+  def self.fetch_competition(competition_id)
     uri = URI("https://www.worldcubeassociation.org/api/v0/competitions/#{competition_id}")
     res = Net::HTTP.get_response(uri)
     if res.is_a?(Net::HTTPSuccess)
       body = JSON.parse res.body
-      body['registration_open'].present?
+      return body
     else
       Metrics.registration_competition_api_error_counter.increment
       puts 'network request failed'
       false
     end
+  end
+
+  def self.is_open?(competition_id)
+    competition_info = Rails.cache.fetch(competition_id, expires_in: 5.minutes) do
+      self.fetch_competition(competition_id)
+    end
+    competition_info["registration_open"] < Time.now && competition_info["registration_close"] > Time.now
+  end
+
+  def self.events_held?(event_ids, competition_id)
+    competition_info = Rails.cache.fetch(competition_id, expires_in: 5.minutes) do
+      self.fetch_competition(competition_id)
+    end
+    competition_info["event_ids"].to_set.superset?(event_ids.to_set)
   end
 end

--- a/app/helpers/user_api.rb
+++ b/app/helpers/user_api.rb
@@ -4,14 +4,14 @@ require 'uri'
 require 'net/http'
 require 'json'
 
-class CompetitorApi
-  def self.check_competitor(competitor_id)
-    uri = URI("https://www.worldcubeassociation.org/api/v0/users/#{competitor_id}")
+class UserApi
+  def self.fetch_user(user_id)
+    uri = URI("https://www.worldcubeassociation.org/api/v0/users/#{user_id}")
     begin
       res = Net::HTTP.get_response(uri)
       if res.is_a?(Net::HTTPSuccess)
         body = JSON.parse res.body
-        body['user'].present?
+        return body["user"]
       else
         # The Competitor Service is unreachable
         Metrics.registration_competitor_api_error_counter.increment
@@ -23,5 +23,14 @@ class CompetitorApi
       Metrics.registration_competitor_api_error_counter.increment
       false
     end
+  end
+  def profile_complete?(user_id)
+    # This needs to come from the user service*, but currently no route exists that gives this info
+    true
+  end
+
+  def is_banned?(user_id)
+    # This needs to come from the user service*, but currently no route exists that gives this info
+    false
   end
 end


### PR DESCRIPTION
Adds validations for the create and update routes according to the monolith. 

TODO:
- I could extend this PR to include the other routes, but that would require mocking some kind of `user_permissions` endpoint