### PR TITLE
Add guests/administrative comments

### DIFF
--- a/Frontend/src/api/registration/get/get_registrations.ts
+++ b/Frontend/src/api/registration/get/get_registrations.ts
@@ -16,6 +16,8 @@ export interface RegistrationAdmin {
   registration_status: RegistrationStatus
   registered_on: string
   comment: string
+  admin_comment: string
+  guests: number
   user: User
 }
 

--- a/Frontend/src/api/types.d.ts
+++ b/Frontend/src/api/types.d.ts
@@ -14,6 +14,7 @@ interface UpdateRegistrationBody {
   status?: string
   event_ids?: EventId[]
   comment?: string
+  admin_comment?: string
 }
 
 type GetRegistrationBody = Record<string, never>

--- a/Frontend/src/pages/register/components/RegistrationPanel.jsx
+++ b/Frontend/src/pages/register/components/RegistrationPanel.jsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { EventSelector, UiIcon } from '@thewca/wca-components'
 import React, { useContext, useEffect, useState } from 'react'
-import { Button, Divider, TextArea } from 'semantic-ui-react'
+import { Button, Divider, Dropdown, Popup, TextArea } from 'semantic-ui-react'
 import { AuthContext } from '../../../api/helper/context/auth_context'
 import { CompetitionContext } from '../../../api/helper/context/competition_context'
 import { getSingleRegistration } from '../../../api/registration/get/get_registrations'
@@ -16,6 +16,7 @@ export default function RegistrationPanel() {
   const { competitionInfo } = useContext(CompetitionContext)
   const [comment, setComment] = useState('')
   const [selectedEvents, setSelectedEvents] = useState([])
+  const [guests, setGuests] = useState(0)
   const [registration, setRegistration] = useState({})
   const queryClient = useQueryClient()
   const { data: registrationRequest, isLoading } = useQuery({
@@ -31,6 +32,7 @@ export default function RegistrationPanel() {
       setRegistration(registrationRequest.registration)
       setComment(registrationRequest.registration.comment)
       setSelectedEvents(registrationRequest.registration.event_ids)
+      setGuests(registrationRequest.registration.guests)
     }
   }, [registrationRequest])
   const { mutate: updateRegistrationMutation, isLoading: isUpdating } =
@@ -131,8 +133,29 @@ export default function RegistrationPanel() {
         </div>
         <div className={styles.commentWrapper}>
           <TextArea
+            maxLength={180}
             onChange={(_, data) => setComment(data.value)}
             value={comment}
+          />
+          <div className={styles.commentCounter}>{comment.length}/180</div>
+        </div>
+      </div>
+      <div className={styles.registrationRow}>
+        <div className={styles.eventSelectionText}>
+          <div className={styles.eventSelectionHeading}>Guests</div>
+        </div>
+        <div className={styles.commentWrapper}>
+          <Dropdown
+            value={guests}
+            onChange={(e, data) => setGuests(data.value)}
+            selection
+            options={[...new Array(10)].map((_, index) => {
+              return {
+                key: `registration-guest-dropdown-${index}`,
+                text: index,
+                value: index,
+              }
+            })}
           />
         </div>
       </div>
@@ -152,6 +175,7 @@ export default function RegistrationPanel() {
                   user_id: registration.user_id,
                   competition_id: competitionInfo.id,
                   comment,
+                  guests,
                   event_ids: selectedEvents,
                 })
               }}
@@ -166,7 +190,6 @@ export default function RegistrationPanel() {
                 updateRegistrationMutation({
                   user_id: registration.user_id,
                   competition_id: competitionInfo.id,
-                  comment,
                   status: 'deleted',
                 })
               }}
@@ -177,8 +200,16 @@ export default function RegistrationPanel() {
         ) : (
           <div className={styles.registrationButtonWrapper}>
             <div className={styles.registrationWarning}>
-              Submission of Registration does not mean approval to compete.
-              <UiIcon name="circle info" />
+              <Popup
+                content="You will only be accepted if you have met all reigstration requirements"
+                position="top center"
+                trigger={
+                  <span>
+                    Submission of Registration does not mean approval to compete{' '}
+                    <UiIcon name="circle info" />
+                  </span>
+                }
+              />
             </div>
             <Button
               className={styles.registrationButton}
@@ -189,6 +220,8 @@ export default function RegistrationPanel() {
                   user_id: user,
                   competition_id: competitionInfo.id,
                   event_ids: selectedEvents,
+                  comment,
+                  guests,
                 })
               }}
               positive

--- a/Frontend/src/pages/register/components/panel.module.scss
+++ b/Frontend/src/pages/register/components/panel.module.scss
@@ -58,6 +58,12 @@
       border-radius: 20px;
       border-color: black;
       padding: 7px;
+      font-size: $sub-header-size;
+    }
+    .comment-counter{
+      font-size: $sub-header-size;
+      margin-top: $single-margin;
+      float: right;
     }
   }
   .registration-button-wrapper{

--- a/Frontend/src/pages/register/index.jsx
+++ b/Frontend/src/pages/register/index.jsx
@@ -24,6 +24,7 @@ export default function Register() {
         </div>
         <div className={styles.requirementText}>
           <Popup
+            position="top right"
             content="You need a WCA Account to register"
             trigger={
               <span>
@@ -33,6 +34,7 @@ export default function Register() {
           />
           <br />
           <Popup
+            position="top right"
             content="Once the competitor Limit has been reached you will be put onto the waiting list"
             trigger={
               <span>
@@ -43,6 +45,7 @@ export default function Register() {
           />
           <br />
           <Popup
+            position="top right"
             content="You will get a full refund before this date"
             trigger={
               <span>
@@ -57,6 +60,7 @@ export default function Register() {
           <br />
           <Popup
             content="You can edit your registration until this date"
+            position="top right"
             trigger={
               <span>
                 Edit Registration until{' '}

--- a/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
+++ b/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
@@ -175,7 +175,7 @@ function RegistrationAdministrationTable({
   selected,
 }) {
   return (
-    <Table textAlign="left" className={styles.list}>
+    <Table textAlign="left" className={styles.list} singleLine>
       <Table.Header>
         <Table.Row>
           <Table.HeaderCell>
@@ -258,8 +258,16 @@ function RegistrationAdministrationTable({
                 </Table.Cell>
                 <Table.Cell>{registration.event_ids.length}</Table.Cell>
                 <Table.Cell>{registration.guests}</Table.Cell>
-                <Table.Cell>{registration.comment}</Table.Cell>
-                <Table.Cell>{registration.admin_comment}</Table.Cell>
+                <Table.Cell title={registration.comment}>
+                  {registration?.comment?.length > 12
+                    ? registration.comment.slice(0, 12) + '...'
+                    : registration.comment}
+                </Table.Cell>
+                <Table.Cell title={registration.admin_comment}>
+                  {registration?.admin_comment?.length > 12
+                    ? registration.admin_comment.slice(0, 12) + '...'
+                    : registration.admin_comment}
+                </Table.Cell>
                 <Table.Cell>
                   <a
                     href={`mailto:${registration.user_id}@worldcubeassociation.org`}

--- a/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
+++ b/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { FlagIcon } from '@thewca/wca-components'
+import { FlagIcon, UiIcon } from '@thewca/wca-components'
 import React, { useContext, useMemo, useReducer } from 'react'
 import { Link } from 'react-router-dom'
 import { Checkbox, Popup, Table } from 'semantic-ui-react'
@@ -195,7 +195,10 @@ function RegistrationAdministrationTable({
           <Table.HeaderCell>Citizen of</Table.HeaderCell>
           <Table.HeaderCell>Registered on</Table.HeaderCell>
           <Table.HeaderCell>Number of Events</Table.HeaderCell>
+          <Table.HeaderCell>Guests</Table.HeaderCell>
           <Table.HeaderCell>Comment</Table.HeaderCell>
+          <Table.HeaderCell>Administrative notes</Table.HeaderCell>
+          <Table.HeaderCell>Email</Table.HeaderCell>
         </Table.Row>
       </Table.Header>
       <Table.Body>
@@ -254,7 +257,16 @@ function RegistrationAdministrationTable({
                   />
                 </Table.Cell>
                 <Table.Cell>{registration.event_ids.length}</Table.Cell>
+                <Table.Cell>{registration.guests}</Table.Cell>
                 <Table.Cell>{registration.comment}</Table.Cell>
+                <Table.Cell>{registration.admin_comment}</Table.Cell>
+                <Table.Cell>
+                  <a
+                    href={`mailto:${registration.user_id}@worldcubeassociation.org`}
+                  >
+                    <UiIcon name="mail" />
+                  </a>
+                </Table.Cell>
               </Table.Row>
             )
           })

--- a/Frontend/src/pages/registration_administration/components/list.module.scss
+++ b/Frontend/src/pages/registration_administration/components/list.module.scss
@@ -15,4 +15,3 @@
   margin-top: $triple-margin;
   margin-bottom: $triple-margin;
 }
-

--- a/Frontend/src/pages/registration_edit/components/RegistrationEditor.jsx
+++ b/Frontend/src/pages/registration_edit/components/RegistrationEditor.jsx
@@ -15,6 +15,7 @@ export default function RegistrationEditor() {
   const { user_id } = useParams()
   const { competitionInfo } = useContext(CompetitionContext)
   const [comment, setComment] = useState('')
+  const [adminComment, setAdminComment] = useState('')
   const [status, setStatus] = useState('')
   const [selectedEvents, setSelectedEvents] = useState([])
   const [registration, setRegistration] = useState({})
@@ -53,6 +54,7 @@ export default function RegistrationEditor() {
       setComment(serverRegistration.registration.comment)
       setStatus(serverRegistration.registration.registration_status)
       setSelectedEvents(serverRegistration.registration.event_ids)
+      setAdminComment(serverRegistration.registration.admin_comment)
     }
   }, [serverRegistration])
 
@@ -70,41 +72,56 @@ export default function RegistrationEditor() {
             size="2x"
           />
           <h3> Comment </h3>
-          <TextArea
-            value={comment}
-            onChange={(_, data) => {
-              setComment(data.value)
-            }}
-          />
+          <div className={styles.commentWrapper}>
+            <TextArea
+              maxLength={180}
+              value={comment}
+              onChange={(_, data) => {
+                setComment(data.value)
+              }}
+            />
+          </div>
+          <h3> Administrative Notes </h3>
+          <div className={styles.commentWrapper}>
+            <TextArea
+              maxLength={180}
+              value={adminComment}
+              onChange={(_, data) => {
+                setAdminComment(data.value)
+              }}
+            />
+          </div>
           <h3> Status </h3>
-          <Checkbox
-            radio
-            label="Accepted"
-            name="checkboxRadioGroup"
-            value="accepted"
-            checked={status === 'accepted'}
-            onChange={(_, data) => setStatus(data.value)}
-          />
-          <br />
-          <Checkbox
-            radio
-            label="Waiting"
-            name="checkboxRadioGroup"
-            value="waiting"
-            checked={status === 'waiting'}
-            onChange={(_, data) => setStatus(data.value)}
-          />
-          <br />
-          <Checkbox
-            radio
-            label="Deleted"
-            name="checkboxRadioGroup"
-            value="deleted"
-            checked={status === 'deleted'}
-            onChange={(_, data) => setStatus(data.value)}
-          />
-          <br />
+          <div className={styles.registrationStatus}>
+            <Checkbox
+              radio
+              label="Accepted"
+              name="checkboxRadioGroup"
+              value="accepted"
+              checked={status === 'accepted'}
+              onChange={(_, data) => setStatus(data.value)}
+            />
+            <br />
+            <Checkbox
+              radio
+              label="Waiting"
+              name="checkboxRadioGroup"
+              value="waiting"
+              checked={status === 'waiting'}
+              onChange={(_, data) => setStatus(data.value)}
+            />
+            <br />
+            <Checkbox
+              radio
+              label="Deleted"
+              name="checkboxRadioGroup"
+              value="deleted"
+              checked={status === 'deleted'}
+              onChange={(_, data) => setStatus(data.value)}
+            />
+          </div>
           <Button
+            color="blue"
             onClick={() => {
               setMessage('Updating Registration', 'basic')
               updateRegistrationMutation({
@@ -113,6 +130,7 @@ export default function RegistrationEditor() {
                 status,
                 event_id: selectedEvents,
                 comment,
+                admin_comment: adminComment,
               })
             }}
           >

--- a/Frontend/src/pages/registration_edit/components/editor.module.scss
+++ b/Frontend/src/pages/registration_edit/components/editor.module.scss
@@ -1,3 +1,20 @@
+@import '../../../style/font-sizes';
+@import '../../../style/margins';
+
 .editor{
   display: flex;
+}
+.comment-wrapper{
+  textarea{
+    width: 95%;
+    resize: none;
+    border-radius: 20px;
+    border-color: black;
+    padding: 7px;
+    font-size: $sub-header-size;
+  }
+}
+.registration-status{
+  margin-top: $double-margin;
+  margin-bottom: $double-margin;
 }

--- a/Frontend/src/pages/registration_edit/index.module.scss
+++ b/Frontend/src/pages/registration_edit/index.module.scss
@@ -1,6 +1,3 @@
 .container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: column;
+  padding: 20px
 }

--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -98,7 +98,7 @@ class RegistrationController < ApplicationController
         registration_status: 'waiting',
         event_ids: @event_ids,
         comment: comment,
-        guests: guests
+        guests: guests,
       },
     }
 
@@ -139,7 +139,7 @@ class RegistrationController < ApplicationController
         registered_on: updated_registration["created_at"],
         comment: updated_registration.competing_comment,
         admin_comment: updated_registration.admin_comment,
-        guests: updated_registration.guests
+        guests: updated_registration.guests,
       } }
     rescue StandardError => e
       puts e
@@ -243,9 +243,8 @@ class RegistrationController < ApplicationController
             registration_status: x.competing_status,
             registered_on: x["created_at"],
             comment: x.competing_comment,
-            guests: x.guests ,
-            admin_comment: x.admin_comment
-          }
+            guests: x.guests,
+            admin_comment: x.admin_comment }
         end
       end
     end
@@ -259,7 +258,7 @@ class RegistrationController < ApplicationController
         registered_on: registration["created_at"],
         comment: registration.competing_comment,
         admin_comment: registration.admin_comment,
-        guests: registration.guests
+        guests: registration.guests,
       }
     end
 end

--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -85,6 +85,7 @@ class RegistrationController < ApplicationController
 
   def create
     comment = params[:comment] || ""
+    guests = params[:guests] || 0
 
     id = SecureRandom.uuid
 
@@ -97,6 +98,7 @@ class RegistrationController < ApplicationController
         registration_status: 'waiting',
         event_ids: @event_ids,
         comment: comment,
+        guests: guests
       },
     }
 
@@ -123,17 +125,21 @@ class RegistrationController < ApplicationController
   def update
     status = params[:status]
     comment = params[:comment]
+    admin_comment = params[:admin_comment]
+    guests = params[:guests]
     event_ids = params[:event_ids]
 
     begin
       registration = Registration.find("#{@competition_id}-#{@user_id}")
-      updated_registration = registration.update_competing_lane!({ status: status, comment: comment, event_ids: event_ids })
+      updated_registration = registration.update_competing_lane!({ status: status, comment: comment, event_ids: event_ids, admin_comment: admin_comment, guests: guests })
       render json: { status: 'ok', registration: {
         user_id: updated_registration["user_id"],
         event_ids: updated_registration.event_ids,
         registration_status: updated_registration.competing_status,
         registered_on: updated_registration["created_at"],
         comment: updated_registration.competing_comment,
+        admin_comment: updated_registration.admin_comment,
+        guests: updated_registration.guests
       } }
     rescue StandardError => e
       puts e
@@ -236,7 +242,10 @@ class RegistrationController < ApplicationController
             event_ids: x.event_ids,
             registration_status: x.competing_status,
             registered_on: x["created_at"],
-            comment: x.competing_comment }
+            comment: x.competing_comment,
+            guests: x.guests ,
+            admin_comment: x.admin_comment
+          }
         end
       end
     end
@@ -249,6 +258,8 @@ class RegistrationController < ApplicationController
         registration_status: registration.competing_status,
         registered_on: registration["created_at"],
         comment: registration.competing_comment,
+        admin_comment: registration.admin_comment,
+        guests: registration.guests
       }
     end
 end

--- a/app/helpers/lane_factory.rb
+++ b/app/helpers/lane_factory.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 class LaneFactory
-  def self.competing_lane(event_ids = [], comment = "", guests=0)
+  def self.competing_lane(event_ids = [], comment = "", guests = 0)
     competing_lane = Lane.new({})
     competing_lane.lane_name = "competing"
     competing_lane.completed_steps = ["Event Registration"]
     competing_lane.lane_details = {
       event_details: event_ids.map { |event_id| { event_id: event_id } },
       comment: comment,
-      guests: guests
+      guests: guests,
     }
     competing_lane
   end

--- a/app/helpers/lane_factory.rb
+++ b/app/helpers/lane_factory.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 class LaneFactory
-  def self.competing_lane(event_ids = [], comment = "")
+  def self.competing_lane(event_ids = [], comment = "", guests=0)
     competing_lane = Lane.new({})
     competing_lane.lane_name = "competing"
-    if event_ids != []
-      competing_lane.completed_steps = ["Event Registration"]
-      competing_lane.lane_details = {
-        event_details: event_ids.map { |event_id| { event_id: event_id } },
-      }
-    end
+    competing_lane.completed_steps = ["Event Registration"]
+    competing_lane.lane_details = {
+      event_details: event_ids.map { |event_id| { event_id: event_id } },
+      comment: comment,
+      guests: guests
+    }
     competing_lane
   end
 end

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -23,11 +23,22 @@ class Registration
     lanes.filter_map { |x| x.lane_details["comment"] if x.lane_name == "competing" }[0]
   end
 
+  # TODO: Change this when we introduce a guest lane
+  def guests
+    lanes.filter_map { |x| x.lane_details["guests"] if x.lane_name == "competing" }[0]
+  end
+
+  def admin_comment
+    lanes.filter_map { |x| x.lane_details["admin_comment"] if x.lane_name == "competing" }[0]
+  end
+
   def update_competing_lane!(update_params)
     updated_lanes = lanes.map do |lane|
       if lane.lane_name == "competing"
         lane.lane_state = update_params[:status] if update_params[:status].present?
         lane.lane_details["comment"] = update_params[:comment] if update_params[:comment].present?
+        lane.lane_details["guests"] = update_params[:guests] if update_params[:guests].present?
+        lane.lane_details["admin_comment"] = update_params[:admin_comment] if update_params[:admin_comment].present?
         lane.lane_details["event_details"] = update_params[:event_ids].map { |event_id| { event_id: event_id } } if update_params[:event_ids].present?
       end
       lane

--- a/app/worker/registration_processor.rb
+++ b/app/worker/registration_processor.rb
@@ -27,7 +27,8 @@ class RegistrationProcessor
       event_registration(message['competition_id'],
                          message['user_id'],
                          message['step_details']['event_ids'],
-                         message['step_details']['comment'])
+                         message['step_details']['comment'],
+                         message['step_details']['guests'])
     end
   end
 
@@ -40,14 +41,13 @@ class RegistrationProcessor
       empty_registration.save!
     end
 
-    def event_registration(competition_id, user_id, event_ids, comment)
+    def event_registration(competition_id, user_id, event_ids, comment, guests)
       registration = Registration.find("#{competition_id}-#{user_id}")
-      competing_lane = LaneFactory.competing_lane(event_ids, comment)
+      competing_lane = LaneFactory.competing_lane(event_ids, comment, guests)
       if registration.lanes.nil?
         registration.update_attributes(lanes: [competing_lane])
       else
         registration.update_attributes(lanes: registration.lanes.append(competing_lane))
       end
-      registration.save!
     end
 end


### PR DESCRIPTION
This PR adds guests/administrative comments as a feature when registering/when administrating registrations. 

In the future we will have a separate guest lane, which allows for guest only registering with payment, but this is not part of this iteration. 