### PR TITLE
Fix Active Tab Index not being Correct on Refresh

### DIFF
--- a/Frontend/src/ui/Tabs.jsx
+++ b/Frontend/src/ui/Tabs.jsx
@@ -1,15 +1,39 @@
 import { UiIcon } from '@thewca/wca-components'
 import React, { useContext, useMemo } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { Menu, Tab } from 'semantic-ui-react'
 import { CompetitionContext } from '../api/helper/context/competition_context'
 import { PermissionsContext } from '../api/helper/context/permission_context'
 import styles from './tabs.module.scss'
 
+function pathMatch(name, pathname) {
+  const registerExpression = /\/competitions\/[a-zA-Z0-9]+\/register/
+  const registrationsExpression =
+    /\/competitions\/[a-zA-Z0-9]+\/registrations\/edit/
+  const competitorsExpression = /\/competitions\/[a-zA-Z0-9]+\/registrations/
+  const infoExpression = /\/competitions\/[a-zA-Z0-9]+\//
+  switch (name) {
+    case 'register':
+      return registerExpression.test(pathname)
+    case 'registrations':
+      return registrationsExpression.test(pathname)
+    case 'competitors':
+      return competitorsExpression.test(pathname)
+    case 'info':
+      return infoExpression.test(pathname)
+    default: {
+      // We are in a custom tab
+      const tabId = name.slice(5)
+      return tabId === pathname.split('/tabs/')[1]
+    }
+  }
+}
+
 export default function PageTabs() {
   const { competitionInfo } = useContext(CompetitionContext)
   const { canAdminCompetition } = useContext(PermissionsContext)
   const navigate = useNavigate()
+  const location = useLocation()
   const panes = useMemo(() => {
     const optionalTabs = []
     if (competitionInfo.use_wca_registration) {
@@ -17,6 +41,7 @@ export default function PageTabs() {
         menuItem: (
           <Menu.Item
             key="tab-register"
+            name="register"
             className={styles.tabItem}
             onClick={() =>
               navigate(`/competitions/${competitionInfo.id}/register`)
@@ -33,7 +58,8 @@ export default function PageTabs() {
       optionalTabs.push({
         menuItem: (
           <Menu.Item
-            key="tab-registration"
+            key="tab-registrations"
+            name="registrations"
             className={styles.tabItem}
             onClick={() =>
               navigate(`/competitions/${competitionInfo.id}/registrations/edit`)
@@ -51,6 +77,7 @@ export default function PageTabs() {
         menuItem: (
           <Menu.Item
             key="tab-Competitors"
+            name="competitors"
             className={styles.tabItem}
             onClick={() =>
               navigate(`/competitions/${competitionInfo.id}/registrations`)
@@ -68,6 +95,7 @@ export default function PageTabs() {
         menuItem: (
           <Menu.Item
             key="tab-info"
+            name="info"
             className={styles.tabItem}
             onClick={() => navigate(`/competitions/${competitionInfo.id}`)}
           >
@@ -83,6 +111,7 @@ export default function PageTabs() {
           menuItem: (
             <Menu.Item
               key={`tabs-${tab.id}`}
+              name={`tabs-${tab.id}`}
               className={styles.tabItem}
               onClick={() =>
                 navigate(`/competitions/${competitionInfo.id}/tabs/${tab.id}`)
@@ -103,12 +132,18 @@ export default function PageTabs() {
     competitionInfo.tabs,
     navigate,
   ])
+
   return (
     <Tab
       panes={panes}
       renderActiveOnly={true}
       menu={{ secondary: true, pointing: true }}
-      defaultActiveIndex={0} //TODO figure out how to set this correctly based on the route
+      // This is only relevant on refresh, why we don't need to use useEffect
+      defaultActiveIndex={
+        panes.findIndex((pane) => {
+          return pathMatch(pane.menuItem.props.name, location.pathname)
+        }) ?? 0
+      }
     />
   )
 }

--- a/Frontend/src/ui/Tabs.jsx
+++ b/Frontend/src/ui/Tabs.jsx
@@ -11,7 +11,7 @@ function pathMatch(name, pathname) {
   const registrationsExpression =
     /\/competitions\/[a-zA-Z0-9]+\/registrations\/edit/
   const competitorsExpression = /\/competitions\/[a-zA-Z0-9]+\/registrations/
-  const infoExpression = /\/competitions\/[a-zA-Z0-9]+\//
+  const infoExpression = /\/competitions\/[a-zA-Z0-9]+\/$/
   switch (name) {
     case 'register':
       return registerExpression.test(pathname)


### PR DESCRIPTION
Currently, when you refresh the page, the active index is not set correctly. I fix this by using react-router's `useLocation` to set the index of the Tabs Component based on the pathname