### PR TITLE
Update Test Competitions

### DIFF
--- a/Frontend/src/ui/Header.jsx
+++ b/Frontend/src/ui/Header.jsx
@@ -9,13 +9,13 @@ const DROPDOWNS = [
     title: 'Registration System',
     items: [
       {
-        path: '/competitions/BanjaLukaCubeDay2023',
+        path: '/competitions/KoelnerKubing2023',
         icon: 'frog',
         title: 'Open Competition',
         reactRoute: true,
       },
       {
-        path: '/competitions/DarmstadtDodecahedronDays2023',
+        path: '/competitions/RheinNeckarAutumn2023',
         icon: 'fish',
         title: 'Open Competition with Payments',
         reactRoute: true,
@@ -27,7 +27,7 @@ const DROPDOWNS = [
         reactRoute: true,
       },
       {
-        path: '/competitions/BrizZonSylwesterOpen2023',
+        path: '/competitions/ManchesterSpring2024',
         icon: 'time',
         title: 'Not yet open Competition',
         reactRoute: true,


### PR DESCRIPTION
Having to update these a second time makes me very aware that relying on the external API for development is just not a good solution. I looked into mocking the `competitionInfo` route, but the amount of data is just so vast and nested it just creates so much clutter. I think the only solution is to run the monolith beside it in docker to have 'real' data? 

Not sure, would love to know some other opinions.