### PR TITLE
Add Vault Identity Tokens to authenticate to the monolith

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
     - 'Frontend/**/*'
     - 'bin/**/*'
     - 'vendor/**/*'
+    - 'infra/**/*'
 
 Bundler/OrderedGems:
   Enabled: false

--- a/Frontend/src/api/schema.d.ts
+++ b/Frontend/src/api/schema.d.ts
@@ -6,7 +6,7 @@
 
 export interface paths {
   "/api/v1/registrations/{competition_id}": {
-    /** List registrations for a given competition_id */
+    /** Public: list registrations for a given competition_id */
     get: {
       parameters: {
         path: {
@@ -14,25 +14,25 @@ export interface paths {
         };
       };
       responses: {
-        /** @description Valid competition_id but no registrations for it */
+        /** @description PASSING comp service down but registrations exist */
         200: {
           content: {
             "application/json": components["schemas"]["registration"][];
           };
         };
-        /** @description Competition ID doesnt exist */
+        /** @description PASSING Competition ID doesnt exist */
         404: {
           content: {
             "application/json": components["schemas"]["error_response"];
           };
         };
-        /** @description Competition service unavailable - 500 error */
+        /** @description PASSING Competition service unavailable - 500 error */
         500: {
           content: {
             "application/json": components["schemas"]["error_response"];
           };
         };
-        /** @description Competition service unavailable - 502 error */
+        /** @description PASSING Competition service unavailable - 502 error */
         502: {
           content: {
             "application/json": components["schemas"]["error_response"];
@@ -41,31 +41,52 @@ export interface paths {
       };
     };
   };
-  "/api/v1/register": {
-    /** Add an attendee registration */
-    post: {
+  "/api/v1/registrations/{competition_id}/admin": {
+    /** Public: list registrations for a given competition_id */
+    get: {
       parameters: {
-        header?: {
-          Authorization?: string;
-        };
-      };
-      requestBody: {
-        content: {
-          "application/json": components["schemas"]["submitRegistrationBody"];
+        path: {
+          competition_id: string;
         };
       };
       responses: {
-        /** @description only required fields included */
-        202: {
+        /** @description PASSING organizer has access to comp 2 */
+        200: {
           content: {
-            "application/json": components["schemas"]["success_response"];
+            "application/json": components["schemas"]["registrationAdmin"][];
           };
         };
-        /** @description user impersonation attempt */
+        /** @description PASSING organizer cannot access registrations for comps they arent organizing - multi comp auth */
+        401: {
+          content: never;
+        };
+      };
+    };
+  };
+  "/api/v1/register": {
+    /** Add an attendee registration */
+    post: {
+      requestBody: {
+        content: {
+          "application/json": components["schemas"]["registration"];
+        };
+      };
+      responses: {
+        /** @description PASSING only required fields included */
+        202: {
+          content: never;
+        };
+        /** @description PASSING empty payload provided */
+        400: {
+          content: never;
+        };
+        /** @description PASSING user impersonation (no admin permission, JWWT token user_id does not match registration user_id) */
+        401: {
+          content: never;
+        };
+        /** @description PASSING comp not open */
         403: {
-          content: {
-            "application/json": components["schemas"]["error_response"];
-          };
+          content: never;
         };
       };
     };
@@ -90,9 +111,10 @@ export interface components {
     registrationAdmin: {
       user_id: string;
       event_ids: EventId[];
-      comment?: string;
-      admin_comment?: string;
-      guests?: number;
+      comment?: string | null;
+      admin_comment?: string | null;
+      guests?: number | null;
+      email?: string;
     };
     submitRegistrationBody: {
       user_id: string;
@@ -117,6 +139,8 @@ export interface components {
   headers: never;
   pathItems: never;
 }
+
+export type $defs = Record<string, never>;
 
 export type external = Record<string, never>;
 

--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -7,7 +7,7 @@ require_relative '../helpers/user_api'
 require_relative '../helpers/error_codes'
 
 class RegistrationController < ApplicationController
-  skip_before_action :validate_token, only: [:list]
+  skip_before_action :validate_token, only: [:list, :token_test]
   # The order of the validations is important to not leak any non public info via the API
   # That's why we should always validate a request first, before taking any other before action
   # before_actions are triggered in the order they are defined

--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -7,7 +7,7 @@ require_relative '../helpers/user_api'
 require_relative '../helpers/error_codes'
 
 class RegistrationController < ApplicationController
-  skip_before_action :validate_token, only: [:list, :token_test]
+  skip_before_action :validate_token, only: [:list]
   # The order of the validations is important to not leak any non public info via the API
   # That's why we should always validate a request first, before taking any other before action
   # before_actions are triggered in the order they are defined

--- a/app/helpers/payment_api.rb
+++ b/app/helpers/payment_api.rb
@@ -4,15 +4,20 @@ require_relative 'error_codes'
 require_relative 'wca_api'
 class PaymentApi < WcaApi
   def self.get_ticket(attendee_id, amount, currency_code)
-    token = self.get_wca_token
-    response = HTTParty.post("https://test-registration.worldcubeassociation.org/api/v10/payment/init",
+    response = HTTParty.post(payment_init_path,
                              body: { "attendee_id" => attendee_id, "amount" => amount, "currency_code" => currency_code }.to_json,
-                             headers: { 'X-WCA-Service-Token' => token,
+                             headers: { WCA_API_HEADER => self.get_wca_token,
                                         "Content-Type" => "application/json" })
     unless response.ok?
       puts response
       raise "Error from the payments service"
     end
-    [response["client_secret"], response["connected_account_id"]]
+    response["id"]
   end
+
+  private
+
+    def payment_init_path
+      "#{WCA_HOST}/api/internal/v1/payment/init"
+    end
 end

--- a/app/helpers/payment_api.rb
+++ b/app/helpers/payment_api.rb
@@ -4,10 +4,10 @@ require_relative 'error_codes'
 require_relative 'wca_api'
 class PaymentApi < WcaApi
   def self.get_ticket(attendee_id, amount, currency_code)
-    token = self.get_wca_token
+    self.get_wca_token
     response = HTTParty.post("https://test-registration.worldcubeassociation.org/api/v10/payment/init",
                              body: { "attendee_id" => attendee_id, "amount" => amount, "currency_code" => currency_code }.to_json,
-                             headers: { 'X-WCA-Service-Token' => "token" ,
+                             headers: { 'X-WCA-Service-Token' => "token",
                                         "Content-Type" => "application/json" })
     unless response.ok?
       puts response

--- a/app/helpers/payment_api.rb
+++ b/app/helpers/payment_api.rb
@@ -2,13 +2,12 @@
 
 require_relative 'error_codes'
 require_relative 'wca_api'
-require_relative 'mocks'
 class PaymentApi < WcaApi
   def self.get_ticket(attendee_id, amount, currency_code)
-    token = self.get_wca_token("payments.worldcubeassociation.org")
+    token = self.get_wca_token
     response = HTTParty.post("https://test-registration.worldcubeassociation.org/api/v10/payment/init",
                              body: { "attendee_id" => attendee_id, "amount" => amount, "currency_code" => currency_code }.to_json,
-                             headers: { 'Authorization' => "Bearer: #{token}",
+                             headers: { 'X-WCA-Service-Token' => "token" ,
                                         "Content-Type" => "application/json" })
     unless response.ok?
       puts response

--- a/app/helpers/payment_api.rb
+++ b/app/helpers/payment_api.rb
@@ -4,10 +4,10 @@ require_relative 'error_codes'
 require_relative 'wca_api'
 class PaymentApi < WcaApi
   def self.get_ticket(attendee_id, amount, currency_code)
-    self.get_wca_token
+    token = self.get_wca_token
     response = HTTParty.post("https://test-registration.worldcubeassociation.org/api/v10/payment/init",
                              body: { "attendee_id" => attendee_id, "amount" => amount, "currency_code" => currency_code }.to_json,
-                             headers: { 'X-WCA-Service-Token' => "token",
+                             headers: { 'X-WCA-Service-Token' => token,
                                         "Content-Type" => "application/json" })
     unless response.ok?
       puts response

--- a/app/helpers/user_api.rb
+++ b/app/helpers/user_api.rb
@@ -8,7 +8,7 @@ require_relative 'wca_api'
 class UserApi < WcaApi
   def self.get_permissions(user_id)
     if Rails.env.production?
-      token = self.get_wca_token
+      self.get_wca_token
       HTTParty.get("https://test-registration.worldcubeassociation.org/api/v10/internal/users/#{user_id}/permissions", headers: { 'X-WCA-Service-Token' => "token" })
     else
       Mocks.permissions_mock(user_id)

--- a/app/helpers/user_api.rb
+++ b/app/helpers/user_api.rb
@@ -31,6 +31,7 @@ class UserApi < WcaApi
   end
 
   private
+
     def permissions_path(user_id)
       "#{WCA_HOST}/api/internal/v1/users/#{user_id}/permissions"
     end

--- a/app/helpers/user_api.rb
+++ b/app/helpers/user_api.rb
@@ -8,8 +8,8 @@ require_relative 'wca_api'
 class UserApi < WcaApi
   def self.get_permissions(user_id)
     if Rails.env.production?
-      token = self.get_wca_token("users.worldcubeassociation.org")
-      HTTParty.get("https://test-registration.worldcubeassociation.org/api/v10/internal/users/#{user_id}/permissions", headers: { 'Authorization' => "Bearer: #{token}" })
+      token = self.get_wca_token
+      HTTParty.get("https://test-registration.worldcubeassociation.org/api/v10/internal/users/#{user_id}/permissions", headers: { 'X-WCA-Service-Token' => "token" })
     else
       Mocks.permissions_mock(user_id)
     end

--- a/app/helpers/user_api.rb
+++ b/app/helpers/user_api.rb
@@ -8,8 +8,8 @@ require_relative 'wca_api'
 class UserApi < WcaApi
   def self.get_permissions(user_id)
     if Rails.env.production?
-      self.get_wca_token
-      HTTParty.get("https://test-registration.worldcubeassociation.org/api/v10/internal/users/#{user_id}/permissions", headers: { 'X-WCA-Service-Token' => "token" })
+      token = self.get_wca_token
+      HTTParty.get("https://test-registration.worldcubeassociation.org/api/v10/internal/users/#{user_id}/permissions", headers: { 'X-WCA-Service-Token' => token })
     else
       Mocks.permissions_mock(user_id)
     end

--- a/app/helpers/user_api.rb
+++ b/app/helpers/user_api.rb
@@ -8,8 +8,7 @@ require_relative 'wca_api'
 class UserApi < WcaApi
   def self.get_permissions(user_id)
     if Rails.env.production?
-      token = self.get_wca_token
-      HTTParty.get("https://test-registration.worldcubeassociation.org/api/v10/internal/users/#{user_id}/permissions", headers: { 'X-WCA-Service-Token' => token })
+      HTTParty.get(permissions_path(user_id), headers: { WCA_API_HEADER => self.get_wca_token })
     else
       Mocks.permissions_mock(user_id)
     end
@@ -30,4 +29,9 @@ class UserApi < WcaApi
     end
     permissions["can_administer_competitions"]["scope"] == "*" || permissions["can_administer_competitions"]["scope"].include?(competition_id)
   end
+
+  private
+    def permissions_path(user_id)
+      "#{WCA_HOST}/api/internal/v1/users/#{user_id}/permissions"
+    end
 end

--- a/app/helpers/wca_api.rb
+++ b/app/helpers/wca_api.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 class WcaApi
-  # TODO: switch this to Vault identity tokens https://developer.hashicorp.com/vault/docs/secrets/identity/identity-token
-  def self.get_wca_token(audience)
-    iat = Time.now.to_i
-    jti_raw = [JwtOptions.secret, iat].join(':').to_s
-    jti = Digest::MD5.hexdigest(jti_raw)
-    payload = { data: { service_id: "registration.worldcubeassociation.org" }, aud: audience, exp: Time.now.to_i + JwtOptions.expiry, sub: "registration.worldcubeassociation.org", iat: iat, jti: jti }
-    JWT.encode payload, JwtOptions.secret, JwtOptions.algorithm
+  # Uses Vault ID Tokens: see https://developer.hashicorp.com/vault/docs/secrets/identity/identity-token
+  def self.get_wca_token
+      Vault.with_retries(Vault::HTTPConnectionError) do
+          data = Vault.logical.read("identity/oidc/token/#{@vault_application}")
+          if(data.present?)
+            data.data[:data][:token]
+          else # TODO: should we hard error out here?
+            puts "Tried to get identity token, but got error"
+          end
+      end
   end
 end

--- a/app/helpers/wca_api.rb
+++ b/app/helpers/wca_api.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class WcaApi
+  WCA_API_HEADER = 'X-WCA-Service-Token'
   # Uses Vault ID Tokens: see https://developer.hashicorp.com/vault/docs/secrets/identity/identity-token
   def self.get_wca_token
     Vault.with_retries(Vault::HTTPConnectionError) do

--- a/app/helpers/wca_api.rb
+++ b/app/helpers/wca_api.rb
@@ -3,13 +3,13 @@
 class WcaApi
   # Uses Vault ID Tokens: see https://developer.hashicorp.com/vault/docs/secrets/identity/identity-token
   def self.get_wca_token
-      Vault.with_retries(Vault::HTTPConnectionError) do
-          data = Vault.logical.read("identity/oidc/token/#{@vault_application}")
-          if(data.present?)
-            data.data[:data][:token]
-          else # TODO: should we hard error out here?
-            puts "Tried to get identity token, but got error"
-          end
+    Vault.with_retries(Vault::HTTPConnectionError) do
+      data = Vault.logical.read("identity/oidc/token/#{@vault_application}")
+      if data.present?
+        data.data[:data][:token]
+      else # TODO: should we hard error out here?
+        puts "Tried to get identity token, but got error"
       end
+    end
   end
 end

--- a/infra/handler/variables.tf
+++ b/infra/handler/variables.tf
@@ -42,8 +42,8 @@ variable "host" {
 
 variable "wca_host" {
   type        = string
-  description = "The host for generating absolute URLs in the application"
-  default     = "worldcubeassociation.org"
+  description = "The host for generating URLs to the monolith"
+  default     = "https://worldcubeassociation.org"
 }
 
 variable "shared_resources" {


### PR DESCRIPTION
This turned out to be a very simple change on a code level, but requires a good amount of setup on the vault level:
- Make sure the Vault Internal OIDC Provider is turned on (I called it wca-internal)
- Make sure there exist a role that can generate tokens named after the vault application, you can create it in the vault cli with `write identity/oidc/role/wca-registration key=default ttl=12h`
- Make sure the entity (In this case our ECS Task) has a policy attached that allows reading from the `identity/oidc/token/#{@vault_application}` path

PR to the monolith coming up