### PR TITLE
Move custom components to Semantic

### DIFF
--- a/Frontend/src/api/auth/get_permissions.ts
+++ b/Frontend/src/api/auth/get_permissions.ts
@@ -15,7 +15,3 @@ export async function getPermissions(): Promise<Permissions> {
   }
   return getPermissionsMock()
 }
-
-// TODO: move these to I18n
-export const CAN_ADMINISTER_COMPETITIONS = 'Can Administer Competitions'
-export const CAN_ATTEND_COMPETITIONS = 'Can attend Competitions'

--- a/Frontend/src/api/types.d.ts
+++ b/Frontend/src/api/types.d.ts
@@ -29,6 +29,7 @@ interface CompetitionInfo {
   'on_the_spot_registration': boolean
   'on_the_spot_entry_fee_lowest_denomination': string
   'extra_registration_requirements': string
+  'guests_entry_fee_lowest_denomination': number
   'url': string
   'website': string
   'short_name': string

--- a/Frontend/src/pages/home/index.jsx
+++ b/Frontend/src/pages/home/index.jsx
@@ -5,6 +5,7 @@ import React, { useContext } from 'react'
 import { Container, Grid, Header, Segment } from 'semantic-ui-react'
 import { CompetitionContext } from '../../api/helper/context/competition_context'
 import RegistrationRequirements from '../register/components/RegistrationRequirements'
+import styles from './index.module.scss'
 
 export default function HomePage() {
   const { competitionInfo } = useContext(CompetitionContext)
@@ -14,14 +15,15 @@ export default function HomePage() {
         <RegistrationRequirements />
       </div>
       {competitionInfo.information && (
-        <>
+        <div>
           <Header as="h3">Information:</Header>
           <div
+            className={styles.information}
             dangerouslySetInnerHTML={{
               __html: marked(competitionInfo.information),
             }}
           />
-        </>
+        </div>
       )}
       <Header as="h3">
         Registration Period:

--- a/Frontend/src/pages/home/index.jsx
+++ b/Frontend/src/pages/home/index.jsx
@@ -2,7 +2,7 @@ import { UiIcon } from '@thewca/wca-components'
 import { marked } from 'marked'
 import moment from 'moment'
 import React, { useContext, useState } from 'react'
-import { Button } from 'semantic-ui-react'
+import { Button, Container, Grid, Header, Segment } from 'semantic-ui-react'
 import { CompetitionContext } from '../../api/helper/context/competition_context'
 import RegistrationRequirements from '../register/components/RegistrationRequirements'
 import styles from './index.module.scss'
@@ -11,17 +11,17 @@ export default function HomePage() {
   const { competitionInfo } = useContext(CompetitionContext)
   const [showAllRequirements, setShowAllRequirements] = useState(false)
   return (
-    <div className={styles.homeContainer}>
-      <div className={styles.requirements}>
-        <div>Registration Requirements:</div>
-        <div>[INSERT ORGANIZER MESSAGE REGARDING REQUIREMENTS]</div>
-        {showAllRequirements && <RegistrationRequirements />}
-        <div>
-          <Button onClick={() => setShowAllRequirements(!showAllRequirements)}>
-            View All
-          </Button>
-        </div>
-      </div>
+    <Container>
+      <Header as="h2" attached="top">
+        Registration Requirements:
+        <Header.Subheader>
+          [INSERT ORGANIZER MESSAGE REGARDING REQUIREMENTS]
+        </Header.Subheader>
+      </Header>
+      {showAllRequirements && <RegistrationRequirements />}
+      <Button onClick={() => setShowAllRequirements(!showAllRequirements)}>
+        View All
+      </Button>
       {competitionInfo.information && (
         <div className={styles.information}>
           <div className={styles.informationHeader}>Information:</div>
@@ -47,96 +47,94 @@ export default function HomePage() {
               ).calendar()}`}
         </div>
       </div>
-      <div className={styles.details}>
-        <div>
-          <span className={styles.detailHeader}>Date: </span>
-          {moment(competitionInfo.start_date).format('ll')}
-        </div>
-        <div>
-          <span className={styles.detailHeader}>Start Time: </span>
-          XX:XX PM
-        </div>
-        <div>
-          <span className={styles.detailHeader}>City: </span>
-          {competitionInfo.city}, {competitionInfo.country_iso2}
-        </div>
-        <div>
-          <span className={styles.detailHeader}>Venue: </span>
-          <span
-            dangerouslySetInnerHTML={{ __html: marked(competitionInfo.venue) }}
-          />
-          <ul>
-            <li>
-              <span className={styles.detailHeader}>Address: </span>
-              {competitionInfo.venue_address}
-            </li>
+      <Segment padded attached>
+        <Grid>
+          <Grid.Column width={3}>
+            <Header>Date</Header>
+            <Header>City</Header>
+            <Header>Venue</Header>
+            <Header color="grey">Address</Header>
             {competitionInfo.venue_details && (
-              <li>
-                <span className={styles.detailHeader}>Details: </span>
-                {competitionInfo.venue_details}
-              </li>
+              <Header color="grey">Details</Header>
             )}
-          </ul>
-        </div>
-        <div>
-          <span className={styles.detailHeader}>Competitor Limit: </span>
-          {competitionInfo.competitor_limit}
-        </div>
-        <div>
-          <span className={styles.detailHeader}>Contact: </span>
-          {competitionInfo.contact ? (
-            <span
-              dangerouslySetInnerHTML={{
-                __html: marked(competitionInfo.contact),
-              }}
-            />
-          ) : (
+            <Header>Competitor Limit</Header>
+            <Header>Contact</Header>
+            <Header>Organizers</Header>
+            <Header>Delegates</Header>
+          </Grid.Column>
+          <Grid.Column width={12}>
+            <Header>{moment(competitionInfo.start_date).format('ll')}</Header>
+            <Header>
+              {competitionInfo.city}, {competitionInfo.country_iso2}
+            </Header>
+            <Header>
+              <p
+                dangerouslySetInnerHTML={{
+                  __html: marked(competitionInfo.venue),
+                }}
+              />
+            </Header>
+            <Header color="grey">{competitionInfo.venue_address}</Header>
+            {competitionInfo.venue_details && (
+              <Header color="grey">{competitionInfo.venue_details}</Header>
+            )}
+            <Header>{competitionInfo.competitor_limit}</Header>
+            <Header>
+              {competitionInfo.contact ? (
+                <span
+                  dangerouslySetInnerHTML={{
+                    __html: marked(competitionInfo.contact),
+                  }}
+                />
+              ) : (
+                <a
+                  href={`https://www.worldcubeassociation.org/contact/website?competitionId=${competitionInfo.id}`}
+                  className={styles.delegateLink}
+                >
+                  Organization Team
+                </a>
+              )}
+            </Header>
+            <Header>
+              {competitionInfo.organizers.map((organizer, index) => (
+                <a
+                  key={`competition-organizer-${organizer.id}`}
+                  href={`${process.env.WCA_URL}/persons/${organizer.wca_id}`}
+                >
+                  {organizer.name}
+                  {index !== competitionInfo.organizers.length - 1 ? ', ' : ''}
+                </a>
+              ))}
+            </Header>
+            <Header>
+              {competitionInfo.delegates.map((delegate, index) => (
+                <a
+                  key={`competition-organizer-${delegate.id}`}
+                  href={`${process.env.WCA_URL}/persons/${delegate.wca_id}`}
+                >
+                  {delegate.name}
+                  {index !== competitionInfo.delegates.length - 1 ? ', ' : ''}
+                </a>
+              ))}
+            </Header>
+          </Grid.Column>
+        </Grid>
+        <Header>
+          <UiIcon name="print" />
+          <Header.Content>
+            Download all of the competitions details as a PDF{' '}
             <a
-              href={`https://www.worldcubeassociation.org/contact/website?competitionId=${competitionInfo.id}`}
-              className={styles.delegateLink}
+              href={`https://www.worldcubeassociation.org/competitions/${competitionInfo.id}.pdf`}
             >
-              Organization Team
+              here
             </a>
-          )}
-        </div>
-        <div>
-          <span className={styles.detailHeader}>Organizers: </span>
-          {competitionInfo.organizers.map((organizer) => (
-            <a
-              key={`competition-organizer-${organizer.id}`}
-              href={`mailto:${organizer.email}`}
-              className={styles.delegateLink}
-            >
-              {organizer.name}
-            </a>
-          ))}
-        </div>
-        <div>
-          <span className={styles.detailHeader}>Delegates: </span>
-          {competitionInfo.delegates.map((delegate) => (
-            <a
-              key={`competition-organizer-${delegate.id}`}
-              href={`mailto:${delegate.email}`}
-              className={styles.delegateLink}
-            >
-              {delegate.name}
-            </a>
-          ))}
-        </div>
-        <div>
-          <UiIcon name="print" /> Download all of the competitions details as a
-          PDF{' '}
-          <a
-            href={`https://www.worldcubeassociation.org/competitions/${competitionInfo.id}.pdf`}
-          >
-            here
-          </a>
-        </div>
-      </div>
-      <div className={styles.bookmarked}>
+          </Header.Content>
+        </Header>
+      </Segment>
+      <Header attached="bottom" textAlign="center" as="h2">
         The Competition has been bookmarked{' '}
         {competitionInfo.number_of_bookmarks} times
-      </div>
-    </div>
+      </Header>
+    </Container>
   )
 }

--- a/Frontend/src/pages/home/index.jsx
+++ b/Frontend/src/pages/home/index.jsx
@@ -5,37 +5,27 @@ import React, { useContext, useState } from 'react'
 import { Button, Container, Grid, Header, Segment } from 'semantic-ui-react'
 import { CompetitionContext } from '../../api/helper/context/competition_context'
 import RegistrationRequirements from '../register/components/RegistrationRequirements'
-import styles from './index.module.scss'
 
 export default function HomePage() {
   const { competitionInfo } = useContext(CompetitionContext)
-  const [showAllRequirements, setShowAllRequirements] = useState(false)
   return (
     <Container>
-      <Header as="h2" attached="top">
-        Registration Requirements:
-        <Header.Subheader>
-          [INSERT ORGANIZER MESSAGE REGARDING REQUIREMENTS]
-        </Header.Subheader>
-      </Header>
-      {showAllRequirements && <RegistrationRequirements />}
-      <Button onClick={() => setShowAllRequirements(!showAllRequirements)}>
-        View All
-      </Button>
+      <div>
+        <RegistrationRequirements />
+      </div>
       {competitionInfo.information && (
-        <div className={styles.information}>
-          <div className={styles.informationHeader}>Information:</div>
+        <>
+          <Header as="h3">Information:</Header>
           <div
-            className={styles.informationText}
             dangerouslySetInnerHTML={{
               __html: marked(competitionInfo.information),
             }}
           />
-        </div>
+        </>
       )}
-      <div className={styles.registrationPeriod}>
-        <div className={styles.registrationHeader}>Registration Period:</div>
-        <div className={styles.registrationPeriodText}>
+      <Header as="h3">
+        Registration Period:
+        <Header.Subheader>
           {new Date(competitionInfo.registration_open) < new Date()
             ? `Registration opened ${moment(
                 competitionInfo.registration_open
@@ -45,8 +35,8 @@ export default function HomePage() {
             : `Registration will open ${moment(
                 competitionInfo.registration_open
               ).calendar()}`}
-        </div>
-      </div>
+        </Header.Subheader>
+      </Header>
       <Segment padded attached>
         <Grid>
           <Grid.Column width={3}>
@@ -63,7 +53,13 @@ export default function HomePage() {
             <Header>Delegates</Header>
           </Grid.Column>
           <Grid.Column width={12}>
-            <Header>{moment(competitionInfo.start_date).format('ll')}</Header>
+            <Header>
+              {competitionInfo.start_date === competitionInfo.end_date
+                ? `${moment(competitionInfo.start_date).format('ll')}`
+                : `${moment(competitionInfo.start_date).format(
+                    'll'
+                  )} to ${moment(competitionInfo.end_date).format('ll')}`}
+            </Header>
             <Header>
               {competitionInfo.city}, {competitionInfo.country_iso2}
             </Header>
@@ -89,7 +85,6 @@ export default function HomePage() {
               ) : (
                 <a
                   href={`https://www.worldcubeassociation.org/contact/website?competitionId=${competitionInfo.id}`}
-                  className={styles.delegateLink}
                 >
                   Organization Team
                 </a>

--- a/Frontend/src/pages/home/index.jsx
+++ b/Frontend/src/pages/home/index.jsx
@@ -1,8 +1,8 @@
 import { UiIcon } from '@thewca/wca-components'
 import { marked } from 'marked'
 import moment from 'moment'
-import React, { useContext, useState } from 'react'
-import { Button, Container, Grid, Header, Segment } from 'semantic-ui-react'
+import React, { useContext } from 'react'
+import { Container, Grid, Header, Segment } from 'semantic-ui-react'
 import { CompetitionContext } from '../../api/helper/context/competition_context'
 import RegistrationRequirements from '../register/components/RegistrationRequirements'
 

--- a/Frontend/src/pages/home/index.module.scss
+++ b/Frontend/src/pages/home/index.module.scss
@@ -1,38 +1,3 @@
-@import '../../style/font-sizes';
-@import '../../style/margins';
-@import '../../style/colors';
 .information{
-  font-size: $sub-header-size;
-  line-height: 1.3em;
-  padding: 30px;
-  .information-header{
-    margin-bottom: $double-margin;
-    font-weight: bold;
-  }
-}
-.home-container{
-  padding: 20px;
-}
-.registration-period{
-  font-size: $sub-header-size;
-  line-height: 1.3em;
-  padding: 0 30px 30px;
-  .registration-header{
-    margin-bottom: $double-margin;
-    font-weight: bold;
-  }
-}
-.bookmarked{
-  text-align: center;
-  font-size: $sub-header-size;
-  margin-top: $double-margin;
-}
-.requirements{
-  font-weight: 500;
-  font-size: $sub-header-size;
-  background-color: $requirements-red;
-  border-radius: 28px;
-  padding: 30px;
-  width: 90%;
-  line-height: 3em;
+  font-size: 1.1em;
 }

--- a/Frontend/src/pages/home/index.module.scss
+++ b/Frontend/src/pages/home/index.module.scss
@@ -36,26 +36,3 @@
   width: 90%;
   line-height: 3em;
 }
-.details{
-  font-size: $sub-header-size;
-  line-height: $header-size;
-  background-color: #EBEBEB;
-  margin-top: $triple-margin;
-  border-radius: 28px;
-  padding: 30px;
-  ul{
-    margin: 0;
-  }
-  .detailHeader{
-    font-weight: bold;
-  }
-  p{
-    display: inline;
-  }
-  .delegateLink{
-    margin-right: $single-margin;
-    &::after{
-      content: ',';
-    }
-  }
-}

--- a/Frontend/src/pages/home/index.module.scss
+++ b/Frontend/src/pages/home/index.module.scss
@@ -1,3 +1,6 @@
 .information{
   font-size: 1.1em;
+  img{
+    display: none;
+  }
 }

--- a/Frontend/src/pages/register/components/CompetingStep.jsx
+++ b/Frontend/src/pages/register/components/CompetingStep.jsx
@@ -99,7 +99,7 @@ export default function CompetingStep({ nextStep }) {
           />
         </div>
       )}
-      <div className={processing ? styles.panelProcessing : styles.panel}>
+      <div className={styles.panel}>
         {registration.registration_status ? (
           <>
             <div className={styles.registrationGreeting}>

--- a/Frontend/src/pages/register/components/Processing.jsx
+++ b/Frontend/src/pages/register/components/Processing.jsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import React, { useContext, useEffect, useState } from 'react'
-import { Message } from 'semantic-ui-react'
+import { Message, Modal } from 'semantic-ui-react'
 import { CompetitionContext } from '../../../api/helper/context/competition_context'
 import { UserContext } from '../../../api/helper/context/user_context'
 import { pollRegistrations } from '../../../api/registration/get/poll_registrations'
@@ -29,23 +29,20 @@ export default function Processing({ onProcessingComplete }) {
     }
   }, [data, onProcessingComplete])
   return (
-    <div>
-      <div>Your registration is processing...</div>
-      <div>{data && `Registration status: ${data.status.competing}`}</div>
-      <div>
+    <Modal dimmer="blurring">
+      <Modal.Header>Your registration is processing...</Modal.Header>
+      <Modal.Content>
         {pollCounter > 3 && (
           <Message warning>
             Processing is taking longer than usual, don't go away!
           </Message>
         )}
-      </div>
-      <div>
         {data && data.queueCount > 500 && (
           <Message warning>
             Lots of Registrations being processed, hang tight!
           </Message>
         )}
-      </div>
-    </div>
+      </Modal.Content>
+    </Modal>
   )
 }

--- a/Frontend/src/pages/register/components/RegistrationRequirements.jsx
+++ b/Frontend/src/pages/register/components/RegistrationRequirements.jsx
@@ -6,6 +6,7 @@ import moment from 'moment/moment'
 import React, { useContext, useState } from 'react'
 import { Accordion, Header, Segment } from 'semantic-ui-react'
 import { CompetitionContext } from '../../../api/helper/context/competition_context'
+import styles from './requirements.module.scss'
 
 export default function RegistrationRequirements() {
   const { competitionInfo } = useContext(CompetitionContext)
@@ -15,7 +16,7 @@ export default function RegistrationRequirements() {
     setActiveIndex(activeIndex === index ? -1 : index)
   }
   return (
-    <>
+    <div className={styles.requirements}>
       <Header as="h1" attached="top">
         Registration Requirements
         <Header.Subheader>
@@ -163,6 +164,6 @@ export default function RegistrationRequirements() {
           )}
         </Accordion>
       </Segment>
-    </>
+    </div>
   )
 }

--- a/Frontend/src/pages/register/components/RegistrationRequirements.jsx
+++ b/Frontend/src/pages/register/components/RegistrationRequirements.jsx
@@ -1,21 +1,20 @@
 import { UiIcon } from '@thewca/wca-components'
 import moment from 'moment/moment'
 import React, { useContext } from 'react'
-import { Popup } from 'semantic-ui-react'
+import { Header, Popup, Segment } from 'semantic-ui-react'
 import { CompetitionContext } from '../../../api/helper/context/competition_context'
-import styles from './requirements.module.scss'
 
 export default function RegistrationRequirements() {
   const { competitionInfo } = useContext(CompetitionContext)
   return (
-    <div className={styles.requirementText}>
+    <Segment padded="very" inverted color="orange" attached size="big">
       <Popup
         position="top right"
         content="You need a WCA Account to register"
         trigger={
-          <span>
+          <Header>
             WCA Account Required <UiIcon name="circle info" />
-          </span>
+          </Header>
         }
       />
       <br />
@@ -23,10 +22,10 @@ export default function RegistrationRequirements() {
         position="top right"
         content="Once the competitor Limit has been reached you will be put onto the waiting list"
         trigger={
-          <span>
+          <Header>
             {competitionInfo.competitor_limit} Competitor Limit{' '}
             <UiIcon name="circle info" />
-          </span>
+          </Header>
         }
       />
       <br />
@@ -34,14 +33,14 @@ export default function RegistrationRequirements() {
         position="top right"
         content="You will get a full refund before this date"
         trigger={
-          <span>
+          <Header>
             Full Refund before{' '}
             {moment(
               competitionInfo.refund_policy_limit_date ??
                 competitionInfo.start_date
             ).format('ll')}
             <UiIcon name="circle info" />
-          </span>
+          </Header>
         }
       />
       <br />
@@ -49,16 +48,16 @@ export default function RegistrationRequirements() {
         content="You can edit your registration until this date"
         position="top right"
         trigger={
-          <span>
+          <Header>
             Edit Registration until{' '}
             {moment(
               competitionInfo.event_change_deadline_date ??
                 competitionInfo.end_date
             ).format('ll')}
             <UiIcon name="circle info" />
-          </span>
+          </Header>
         }
       />
-    </div>
+    </Segment>
   )
 }

--- a/Frontend/src/pages/register/components/RegistrationRequirements.jsx
+++ b/Frontend/src/pages/register/components/RegistrationRequirements.jsx
@@ -1,63 +1,166 @@
+import * as currencies from '@dinero.js/currencies'
 import { UiIcon } from '@thewca/wca-components'
+import { dinero, toDecimal } from 'dinero.js'
+import { marked } from 'marked'
 import moment from 'moment/moment'
-import React, { useContext } from 'react'
-import { Header, Popup, Segment } from 'semantic-ui-react'
+import React, { useContext, useState } from 'react'
+import { Accordion, Header, Segment } from 'semantic-ui-react'
 import { CompetitionContext } from '../../../api/helper/context/competition_context'
 
 export default function RegistrationRequirements() {
   const { competitionInfo } = useContext(CompetitionContext)
+  const [activeIndex, setActiveIndex] = useState(-1)
+  const handleClick = (e, titleProps) => {
+    const { index } = titleProps
+    setActiveIndex(activeIndex === index ? -1 : index)
+  }
   return (
-    <Segment padded="very" inverted color="orange" attached size="big">
-      <Popup
-        position="top right"
-        content="You need a WCA Account to register"
-        trigger={
-          <Header>
-            WCA Account Required <UiIcon name="circle info" />
-          </Header>
-        }
-      />
-      <br />
-      <Popup
-        position="top right"
-        content="Once the competitor Limit has been reached you will be put onto the waiting list"
-        trigger={
-          <Header>
-            {competitionInfo.competitor_limit} Competitor Limit{' '}
-            <UiIcon name="circle info" />
-          </Header>
-        }
-      />
-      <br />
-      <Popup
-        position="top right"
-        content="You will get a full refund before this date"
-        trigger={
-          <Header>
-            Full Refund before{' '}
-            {moment(
-              competitionInfo.refund_policy_limit_date ??
-                competitionInfo.start_date
-            ).format('ll')}
-            <UiIcon name="circle info" />
-          </Header>
-        }
-      />
-      <br />
-      <Popup
-        content="You can edit your registration until this date"
-        position="top right"
-        trigger={
-          <Header>
+    <>
+      <Header as="h1" attached="top">
+        Registration Requirements
+        <Header.Subheader>
+          [INSERT ORGANIZER MESSAGE REGARDING REQUIREMENTS]
+        </Header.Subheader>
+      </Header>
+      <Segment padded inverted color="orange" attached size="big">
+        <Accordion inverted>
+          <Accordion.Title
+            active={activeIndex === 0}
+            index={0}
+            onClick={handleClick}
+          >
+            <UiIcon name="dropdown" />
+            WCA Account Required
+          </Accordion.Title>
+          <Accordion.Content active={activeIndex === 0}>
+            <p>
+              You need a WCA Account to register, click{' '}
+              <a href="/users/sign_up">here</a> to create One
+            </p>
+          </Accordion.Content>
+          <Accordion.Title
+            active={activeIndex === 1}
+            index={1}
+            onClick={handleClick}
+          >
+            <UiIcon name="dropdown" />
+            {competitionInfo.competitor_limit} person Competitor Limit
+          </Accordion.Title>
+          <Accordion.Content active={activeIndex === 1}>
+            <p>
+              Once the competitor Limit has been reached you will be put onto
+              the waiting list
+            </p>
+          </Accordion.Content>
+          <Accordion.Title
+            active={activeIndex === 2}
+            index={2}
+            onClick={handleClick}
+          >
+            <UiIcon name="dropdown" />
+            {competitionInfo.refund_policy_percent === 0
+              ? 'No refunds'
+              : `${
+                  competitionInfo.refund_policy_percent
+                }% Refund before ${moment(
+                  competitionInfo.refund_policy_limit_date ??
+                    competitionInfo.start_date
+                ).format('ll')}`}
+          </Accordion.Title>
+          <Accordion.Content active={activeIndex === 2}>
+            <p>
+              You will get a {competitionInfo.refund_policy_percent}% refund
+              before this date.
+            </p>
+          </Accordion.Content>
+          <Accordion.Title
+            active={activeIndex === 3}
+            index={3}
+            onClick={handleClick}
+          >
+            <UiIcon name="dropdown" />
             Edit Registration until{' '}
             {moment(
               competitionInfo.event_change_deadline_date ??
                 competitionInfo.end_date
             ).format('ll')}
-            <UiIcon name="circle info" />
-          </Header>
-        }
-      />
-    </Segment>
+          </Accordion.Title>
+          <Accordion.Content active={activeIndex === 3}>
+            <p>You can edit your registration until this date</p>
+          </Accordion.Content>
+          <Accordion.Title
+            active={activeIndex === 4}
+            index={4}
+            onClick={handleClick}
+          >
+            <UiIcon name="dropdown" />
+            {competitionInfo.base_entry_fee_lowest_denomination
+              ? `${toDecimal(
+                  dinero({
+                    amount: competitionInfo.base_entry_fee_lowest_denomination,
+                    currency: currencies[competitionInfo.currency_code],
+                  }),
+                  ({ value, currency }) => `${currency.code} ${value}`
+                )} registration fee`
+              : 'No registration fee'}
+          </Accordion.Title>
+          <Accordion.Content active={activeIndex === 4}>
+            <p>
+              {competitionInfo.base_entry_fee_lowest_denomination
+                ? // eslint-disable-next-line unicorn/no-nested-ternary
+                  competitionInfo['using_stripe_payments?']
+                  ? 'You will have to pay the registration fee on stripe after registering'
+                  : 'Check the Additional Registration Requirements about how to pay'
+                : 'This competition is free'}
+            </p>
+          </Accordion.Content>
+          <Accordion.Title
+            active={activeIndex === 5}
+            index={5}
+            onClick={handleClick}
+          >
+            <UiIcon name="dropdown" />
+            {competitionInfo.guests_entry_fee_lowest_denomination
+              ? `${toDecimal(
+                  dinero({
+                    amount:
+                      competitionInfo.guests_entry_fee_lowest_denomination,
+                    currency: currencies[competitionInfo.currency_code],
+                  }),
+                  ({ value, currency }) => `${currency.code} ${value}`
+                )} fee for attending guests`
+              : 'No guest fee'}
+          </Accordion.Title>
+          <Accordion.Content active={activeIndex === 5}>
+            <p>
+              {competitionInfo.guests_entry_fee_lowest_denomination
+                ? 'Guests have to pay this amount to attend'
+                : 'Guests attend for free'}
+            </p>
+          </Accordion.Content>
+          {competitionInfo.extra_registration_requirements && (
+            <>
+              <Accordion.Title
+                active={activeIndex === 6}
+                index={6}
+                onClick={handleClick}
+              >
+                <UiIcon name="dropdown" />
+                Additional Registration Requirements
+              </Accordion.Title>
+              <Accordion.Content active={activeIndex === 6}>
+                <p
+                  dangerouslySetInnerHTML={{
+                    __html: marked(
+                      competitionInfo.extra_registration_requirements
+                    ),
+                  }}
+                />
+              </Accordion.Content>{' '}
+            </>
+          )}
+        </Accordion>
+      </Segment>
+    </>
   )
 }

--- a/Frontend/src/pages/register/components/RegistrationRequirements.jsx
+++ b/Frontend/src/pages/register/components/RegistrationRequirements.jsx
@@ -35,7 +35,7 @@ export default function RegistrationRequirements() {
           <Accordion.Content active={activeIndex === 0}>
             <p>
               You need a WCA Account to register, click{' '}
-              <a href="/users/sign_up">here</a> to create One
+              <a href="/users/sign_up">here</a> to create one.
             </p>
           </Accordion.Content>
           <Accordion.Title
@@ -49,7 +49,7 @@ export default function RegistrationRequirements() {
           <Accordion.Content active={activeIndex === 1}>
             <p>
               Once the competitor Limit has been reached you will be put onto
-              the waiting list
+              the waiting list.
             </p>
           </Accordion.Content>
           <Accordion.Title
@@ -69,8 +69,10 @@ export default function RegistrationRequirements() {
           </Accordion.Title>
           <Accordion.Content active={activeIndex === 2}>
             <p>
-              You will get a {competitionInfo.refund_policy_percent}% refund
-              before this date.
+              {competitionInfo.refund_policy_percent === 0
+                ? "Registration fees won't be refunded under any circumstance."
+                : `You will get a ${competitionInfo.refund_policy_percent}% refund
+              before this date.`}
             </p>
           </Accordion.Content>
           <Accordion.Title
@@ -86,7 +88,7 @@ export default function RegistrationRequirements() {
             ).format('ll')}
           </Accordion.Title>
           <Accordion.Content active={activeIndex === 3}>
-            <p>You can edit your registration until this date</p>
+            <p>You can edit your registration until this date.</p>
           </Accordion.Content>
           <Accordion.Title
             active={activeIndex === 4}
@@ -109,8 +111,8 @@ export default function RegistrationRequirements() {
               {competitionInfo.base_entry_fee_lowest_denomination
                 ? // eslint-disable-next-line unicorn/no-nested-ternary
                   competitionInfo['using_stripe_payments?']
-                  ? 'You will have to pay the registration fee on stripe after registering'
-                  : 'Check the Additional Registration Requirements about how to pay'
+                  ? 'You will have to pay the registration fee on stripe after registering.'
+                  : 'Check the Additional Registration Requirements about how to pay.'
                 : 'This competition is free'}
             </p>
           </Accordion.Content>
@@ -134,8 +136,8 @@ export default function RegistrationRequirements() {
           <Accordion.Content active={activeIndex === 5}>
             <p>
               {competitionInfo.guests_entry_fee_lowest_denomination
-                ? 'Guests have to pay this amount to attend'
-                : 'Guests attend for free'}
+                ? 'Guests have to pay this amount to attend.'
+                : 'Guests attend for free.'}
             </p>
           </Accordion.Content>
           {competitionInfo.extra_registration_requirements && (
@@ -156,7 +158,7 @@ export default function RegistrationRequirements() {
                     ),
                   }}
                 />
-              </Accordion.Content>{' '}
+              </Accordion.Content>
             </>
           )}
         </Accordion>

--- a/Frontend/src/pages/register/components/panel.module.scss
+++ b/Frontend/src/pages/register/components/panel.module.scss
@@ -3,10 +3,6 @@
 .panel{
   margin-top: $single-margin;
 }
-.panel-processing{
-  margin-top: $single-margin;
-  filter: blur(8px);
-}
 .registration-greeting{
   text-align: center;
   font-size: $sub-header-size;

--- a/Frontend/src/pages/register/components/processing.module.scss
+++ b/Frontend/src/pages/register/components/processing.module.scss
@@ -1,5 +1,0 @@
-@import '../../../style/font-sizes';
-
-.processing-header{
-  font-size: $sub-header-size;
-}

--- a/Frontend/src/pages/register/components/requirements.module.scss
+++ b/Frontend/src/pages/register/components/requirements.module.scss
@@ -1,15 +1,6 @@
-@import '../../../style/font-sizes';
 @import '../../../style/margins';
-@import '../../../style/colors';
 
-.requirementText{
-  margin-top: $triple-margin;
-  font-weight: 500;
-  font-size: $sub-header-size;
-  background-color: $requirements-red;
-  border-radius: 28px;
-  margin-left: 5%;
-  padding: 30px;
-  width: 90%;
-  line-height: 3em;
+.requirements{
+  margin-top: $double-margin;
+  margin-bottom: $double-margin;
 }

--- a/Frontend/src/pages/register/index.jsx
+++ b/Frontend/src/pages/register/index.jsx
@@ -17,9 +17,6 @@ export default function Register() {
   return (
     <div>
       <div className={styles.requirements}>
-        <Header as="h1" attached="top">
-          Registration Requirements
-        </Header>
         <RegistrationRequirements />
       </div>
       {!loggedIn ? (
@@ -29,7 +26,6 @@ export default function Register() {
       ) : // eslint-disable-next-line unicorn/no-nested-ternary
       competitionInfo['registration_opened?'] ? (
         <div>
-          <Header>Hi, {user.name}</Header>
           {canAttendCompetition ? (
             <StepPanel />
           ) : (

--- a/Frontend/src/pages/register/index.jsx
+++ b/Frontend/src/pages/register/index.jsx
@@ -1,7 +1,6 @@
 import moment from 'moment'
 import React, { useContext } from 'react'
-import { Message } from 'semantic-ui-react'
-import { CAN_ATTEND_COMPETITIONS } from '../../api/auth/get_permissions'
+import { Header, Message } from 'semantic-ui-react'
 import { CompetitionContext } from '../../api/helper/context/competition_context'
 import { PermissionsContext } from '../../api/helper/context/permission_context'
 import { UserContext } from '../../api/helper/context/user_context'
@@ -18,21 +17,26 @@ export default function Register() {
   return (
     <div>
       <div className={styles.requirements}>
-        <div className={styles.requirementsHeader}>
+        <Header as="h1" attached="top">
           Registration Requirements
-        </div>
+        </Header>
         <RegistrationRequirements />
       </div>
       {!loggedIn ? (
-        <h2>You have to log in to Register for a Competition</h2>
+        <PermissionMessage>
+          You need to log in to Register for a competition
+        </PermissionMessage>
       ) : // eslint-disable-next-line unicorn/no-nested-ternary
       competitionInfo['registration_opened?'] ? (
         <div>
-          <div className={styles.registrationHeader}>Hi, {user.name}</div>
+          <Header>Hi, {user.name}</Header>
           {canAttendCompetition ? (
             <StepPanel />
           ) : (
-            <PermissionMessage permissionLevel={CAN_ATTEND_COMPETITIONS} />
+            <PermissionMessage>
+              You are not allowed to Register for a competition, make sure your
+              profile is complete and you are not banned
+            </PermissionMessage>
           )}
         </div>
       ) : (

--- a/Frontend/src/pages/register/index.jsx
+++ b/Frontend/src/pages/register/index.jsx
@@ -1,6 +1,6 @@
 import moment from 'moment'
 import React, { useContext } from 'react'
-import { Header, Message } from 'semantic-ui-react'
+import { Message } from 'semantic-ui-react'
 import { CompetitionContext } from '../../api/helper/context/competition_context'
 import { PermissionsContext } from '../../api/helper/context/permission_context'
 import { UserContext } from '../../api/helper/context/user_context'

--- a/Frontend/src/pages/register/index.jsx
+++ b/Frontend/src/pages/register/index.jsx
@@ -16,7 +16,7 @@ export default function Register() {
   const loggedIn = user !== null
   return (
     <div>
-      <div className={styles.requirements}>
+      <div>
         <RegistrationRequirements />
       </div>
       {!loggedIn ? (

--- a/Frontend/src/pages/register/index.module.scss
+++ b/Frontend/src/pages/register/index.module.scss
@@ -1,24 +1,4 @@
 @import '../../style/font-sizes';
-@import '../../style/margins';
-@import '../../style/colors';
-.registration-header{
-    margin-top: $single-margin;
-    margin-bottom: $double-margin;
-    text-align: center;
-    font-size: $sub-header-size;
-    font-weight: 700;
-    line-height: normal;
-}
-.requirements{
-    margin-top: $single-margin;
-    margin-bottom: $double-margin;
-    .requirements-header{
-        font-size: $header-size;
-        text-align: center;
-        margin-top: $triple-margin;
-        font-weight: 700;
-    }
-}
 .competition-not-open{
     font-size: $sub-header-size;
     padding: 30px;

--- a/Frontend/src/pages/registration_administration/index.jsx
+++ b/Frontend/src/pages/registration_administration/index.jsx
@@ -1,5 +1,4 @@
 import React, { useContext } from 'react'
-import { CAN_ADMINISTER_COMPETITIONS } from '../../api/auth/get_permissions'
 import { PermissionsContext } from '../../api/helper/context/permission_context'
 import PermissionMessage from '../../ui/messages/permissionMessage'
 import RegistrationAdministrationList from './components/RegistrationAdministrationList'
@@ -11,7 +10,9 @@ export default function RegistrationAdministration() {
       {canAdminCompetition ? (
         <RegistrationAdministrationList />
       ) : (
-        <PermissionMessage permissionLevel={CAN_ADMINISTER_COMPETITIONS} />
+        <PermissionMessage>
+          You are not allowed to administrate this competition
+        </PermissionMessage>
       )}
     </div>
   )

--- a/Frontend/src/pages/registration_edit/index.jsx
+++ b/Frontend/src/pages/registration_edit/index.jsx
@@ -1,5 +1,4 @@
 import React, { useContext } from 'react'
-import { CAN_ADMINISTER_COMPETITIONS } from '../../api/auth/get_permissions'
 import { PermissionsContext } from '../../api/helper/context/permission_context'
 import PermissionMessage from '../../ui/messages/permissionMessage'
 import RegistrationEditor from './components/RegistrationEditor'
@@ -12,7 +11,9 @@ export default function RegistrationEdit() {
       {canAdminCompetition ? (
         <RegistrationEditor />
       ) : (
-        <PermissionMessage permissionLevel={CAN_ADMINISTER_COMPETITIONS} />
+        <PermissionMessage>
+          You are not allowed to administrate this competition
+        </PermissionMessage>
       )}
     </div>
   )

--- a/Frontend/src/ui/Competition.jsx
+++ b/Frontend/src/ui/Competition.jsx
@@ -5,7 +5,15 @@ import { dinero, toDecimal } from 'dinero.js'
 import moment from 'moment'
 import React from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { Button, Image } from 'semantic-ui-react'
+import {
+  Button,
+  Container,
+  Grid,
+  Header,
+  Image,
+  Label,
+  Segment,
+} from 'semantic-ui-react'
 import getCompetitionInfo from '../api/competition/get/get_competition_info'
 import { CompetitionContext } from '../api/helper/context/competition_context'
 import { BASE_ROUTE } from '../routes'
@@ -27,70 +35,80 @@ export default function Competition({ children }) {
         <LoadingMessage />
       ) : (
         <>
-          <div className={styles.competitionInfo}>
-            <div className={styles.header}>
-              <div className={styles.infoLeft}>
-                <div className={styles.competitionName}>
-                  <UiIcon name="bookmark ouline" /> {competitionInfo.name} |{' '}
-                  {competitionInfo['registration_opened?'] ? (
-                    <span className={styles.open}>Open</span>
-                  ) : (
-                    <span className={styles.close}>Close</span>
-                  )}
-                </div>
-                <div className={styles.location}>
-                  <UiIcon name="pin" /> {competitionInfo.venue_address}
-                </div>
-                <div className={styles.date}>
-                  {moment(competitionInfo.start_date).format('LL')},{' '}
-                  <a
-                    href={`https://calendar.google.com/calendar/render?action=TEMPLATE&text=${
-                      competitionInfo.id
-                    }&dates=${moment(competitionInfo.start_date).format(
-                      'YYYYMMDD'
-                    )}/${moment(competitionInfo.end_date).format(
-                      'YYYYMMDD'
-                    )}&location=${competitionInfo.venue_address}`}
-                  >
-                    Add to Google Calendar
-                  </a>
-                </div>
-                <div className={styles.announcement}>
-                  *Insert Potential organizer announcement or memo for users to
-                  view before hitting register*
-                </div>
-                <Button
-                  className={styles.registerButton}
-                  disabled={!competitionInfo['registration_opened?']}
-                  onClick={(_, data) => {
-                    if (!data.disabled) {
-                      if (competitionInfo.use_wca_registration) {
-                        navigate(`${BASE_ROUTE}/${competitionInfo.id}/register`)
-                      } else {
-                        window.location =
-                          competitionInfo.external_registration_page
+          <Container>
+            <Segment padded>
+              <Grid>
+                <Grid.Column width={12}>
+                  <Header as="h1">
+                    <UiIcon name="bookmark ouline" />
+                    {competitionInfo['registration_opened?'] ? (
+                      <Header.Content>
+                        {competitionInfo.name} | Open
+                      </Header.Content>
+                    ) : (
+                      <Header.Content>
+                        {competitionInfo.name} | Close
+                      </Header.Content>
+                    )}
+                    <Header.Subheader>
+                      <UiIcon name="pin" /> {competitionInfo.venue_address}
+                    </Header.Subheader>
+                  </Header>
+                  <Header as="h2">
+                    {moment(competitionInfo.start_date).format('LL')},{' '}
+                    <a
+                      href={`https://calendar.google.com/calendar/render?action=TEMPLATE&text=${
+                        competitionInfo.id
+                      }&dates=${moment(competitionInfo.start_date).format(
+                        'YYYYMMDD'
+                      )}/${moment(competitionInfo.end_date).format(
+                        'YYYYMMDD'
+                      )}&location=${competitionInfo.venue_address}`}
+                    >
+                      Add to Google Calendar
+                    </a>
+                  </Header>
+                  <Segment inverted color="red">
+                    *Insert Potential organizer announcement or memo for users
+                    to view before hitting register*
+                  </Segment>
+
+                  <Button
+                    color="orange"
+                    size="massive"
+                    disabled={!competitionInfo['registration_opened?']}
+                    onClick={(_, data) => {
+                      if (!data.disabled) {
+                        if (competitionInfo.use_wca_registration) {
+                          navigate(
+                            `${BASE_ROUTE}/${competitionInfo.id}/register`
+                          )
+                        } else {
+                          window.location =
+                            competitionInfo.external_registration_page
+                        }
                       }
-                    }
-                  }}
-                >
-                  Register
-                </Button>
-                <span className={styles.fee}>
-                  Registration Fee:{' '}
-                  {toDecimal(
-                    dinero({
-                      amount:
-                        competitionInfo.base_entry_fee_lowest_denomination,
-                      currency: currencies[competitionInfo.currency_code],
-                    }),
-                    ({ value, currency }) => `${currency.code} ${value}`
-                  ) ?? 'No Entry Fee'}
-                </span>
-              </div>
-              <div className={styles.infoRight}>
-                <Image href={competitionInfo.url} className={styles.image} />
-              </div>
-            </div>
+                    }}
+                  >
+                    Register
+                  </Button>
+                  <Label size="massive">
+                    Registration Fee:{' '}
+                    {toDecimal(
+                      dinero({
+                        amount:
+                          competitionInfo.base_entry_fee_lowest_denomination,
+                        currency: currencies[competitionInfo.currency_code],
+                      }),
+                      ({ value, currency }) => `${currency.code} ${value}`
+                    ) ?? 'No Entry Fee'}
+                  </Label>
+                </Grid.Column>
+                <Grid.Column width={4}>
+                  <Image href={competitionInfo.url} className={styles.image} />
+                </Grid.Column>
+              </Grid>
+            </Segment>
             <div className={styles.eventList}>
               <div>
                 <span className={styles.eventHeader}>Events:</span>
@@ -110,7 +128,7 @@ export default function Competition({ children }) {
                 </span>
               </div>
             </div>
-          </div>
+          </Container>
           {children}
         </>
       )}

--- a/Frontend/src/ui/Competition.jsx
+++ b/Frontend/src/ui/Competition.jsx
@@ -36,7 +36,7 @@ export default function Competition({ children }) {
       ) : (
         <>
           <Container>
-            <Segment padded>
+            <Segment padded raised>
               <Grid>
                 <Grid.Column width={12}>
                   <Header as="h1">

--- a/Frontend/src/ui/Competition.jsx
+++ b/Frontend/src/ui/Competition.jsx
@@ -2,8 +2,9 @@ import * as currencies from '@dinero.js/currencies'
 import { useQuery } from '@tanstack/react-query'
 import { CubingIcon, UiIcon } from '@thewca/wca-components'
 import { dinero, toDecimal } from 'dinero.js'
+import { marked } from 'marked'
 import moment from 'moment'
-import React from 'react'
+import React, { useMemo } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import {
   Button,
@@ -17,6 +18,7 @@ import {
 import getCompetitionInfo from '../api/competition/get/get_competition_info'
 import { CompetitionContext } from '../api/helper/context/competition_context'
 import { BASE_ROUTE } from '../routes'
+import logo from '../static/wca2020.svg'
 import styles from './competition.module.scss'
 import LoadingMessage from './messages/loadingMessage'
 
@@ -27,6 +29,15 @@ export default function Competition({ children }) {
     queryKey: [competition_id],
     queryFn: () => getCompetitionInfo(competition_id),
   })
+  // Hack before we have an image Icon field in the DB
+  const src = useMemo(() => {
+    if (competitionInfo) {
+      const div = document.createElement('DIV')
+      div.innerHTML = marked(competitionInfo.information)
+      return div.querySelector('img')?.src ?? logo
+    }
+    return ''
+  }, [competitionInfo])
   return (
     <CompetitionContext.Provider
       value={{ competitionInfo: competitionInfo ?? {} }}
@@ -105,7 +116,7 @@ export default function Competition({ children }) {
                   </Label>
                 </Grid.Column>
                 <Grid.Column width={4}>
-                  <Image href={competitionInfo.url} className={styles.image} />
+                  <Image src={src} href={src} centered />
                 </Grid.Column>
               </Grid>
             </Segment>

--- a/Frontend/src/ui/Tabs.jsx
+++ b/Frontend/src/ui/Tabs.jsx
@@ -176,6 +176,7 @@ export default function PageTabs() {
 
   return (
     <Tab
+      className={styles.tabs}
       panes={panes}
       renderActiveOnly={true}
       menu={{ secondary: true, pointing: true }}

--- a/Frontend/src/ui/competition.module.scss
+++ b/Frontend/src/ui/competition.module.scss
@@ -50,14 +50,6 @@
   font-size: $sub-header-size;
   margin-left: $single-margin;
 }
-.image{
-  width: 14vw;
-  height: 100%;
-  border-radius: 26px;
-  border: 7px solid #000;
-  background: #6C6B6B !important;
-  margin-left: 5%;
-}
 .event-list{
   padding: 30px;
   font-size: $sub-header-size;

--- a/Frontend/src/ui/messages/permissionMessage.jsx
+++ b/Frontend/src/ui/messages/permissionMessage.jsx
@@ -1,15 +1,14 @@
 import { UiIcon } from '@thewca/wca-components'
 import React from 'react'
 import { Message } from 'semantic-ui-react'
-import styles from './permission.module.scss'
 
-export default function PermissionMessage({ permissionLevel }) {
+export default function PermissionMessage({ children }) {
   return (
-    <Message icon className={styles.permissions} negative>
+    <Message icon negative>
       <UiIcon name="lock" size="4x" />
       <Message.Content>
         <Message.Header>Unauthorized</Message.Header>
-        You need '{permissionLevel}' Permissions to access this content.
+        {children}
       </Message.Content>
     </Message>
   )

--- a/Frontend/src/ui/tabs.module.scss
+++ b/Frontend/src/ui/tabs.module.scss
@@ -3,3 +3,6 @@
 .tab-item{
   font-size: $menu-size;
 }
+.tabs{
+  overflow-x: auto;
+}


### PR DESCRIPTION
This moves the custom UMD Styling to Semantic Components while keeping the overall Layout and Design.

Components Done:
- Competitions Box
- Registration Requirements
- Permissions Message (was already a semantic component, just removed the width and made for flexible)
- Details Box on the bottom of Home
- Event Step (I think we are mostly fine here)
- Information Section
- Processing