### PR TITLE
Send Current User to Payment Request

### DIFF
--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -143,7 +143,7 @@ class RegistrationController < ApplicationController
     refresh = params[:refresh]
     if refresh || @registration.payment_ticket.nil?
       amount, currency_code = @competition.payment_info
-      ticket = PaymentApi.get_ticket(@registration[:attendee_id], amount, currency_code)
+      ticket = PaymentApi.get_ticket(@registration[:attendee_id], amount, currency_code, @current_user)
       @registration.init_payment_lane(amount, currency_code, ticket)
     else
       ticket = @registration.payment_ticket

--- a/app/helpers/payment_api.rb
+++ b/app/helpers/payment_api.rb
@@ -3,9 +3,9 @@
 require_relative 'error_codes'
 require_relative 'wca_api'
 class PaymentApi < WcaApi
-  def self.get_ticket(attendee_id, amount, currency_code)
+  def self.get_ticket(attendee_id, amount, currency_code, current_user)
     response = HTTParty.post(payment_init_path,
-                             body: { 'attendee_id' => attendee_id, 'amount' => amount, 'currency_code' => currency_code }.to_json,
+                             body: { 'attendee_id' => attendee_id, 'amount' => amount, 'currency_code' => currency_code, 'current_user' => current_user }.to_json,
                              headers: { WCA_API_HEADER => self.get_wca_token,
                                         'Content-Type' => 'application/json' })
     unless response.ok?


### PR DESCRIPTION
Also adds current_user to the post request send to the payment service for cases where it might not be the same as the attendee