### PR TITLE
Regnerate JWT Token on refresh

### DIFF
--- a/Frontend/src/ui/providers/UserProvider.jsx
+++ b/Frontend/src/ui/providers/UserProvider.jsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import React from 'react'
+import { getJWT } from '../../api/auth/get_jwt'
 import { UserContext } from '../../api/helper/context/user_context'
 import getMe from '../../api/user/get/get_me'
 import LoadingMessage from '../messages/loadingMessage'
@@ -14,6 +15,10 @@ export default function UserProvider({ children }) {
     retry: false,
     onError: (_) => {
       // We are not logged in, set user explicitly to undefined?
+    },
+    onSuccess: (_) => {
+      // Get a new token so when a user switches account it overwrites the token
+      getJWT(true)
     },
   })
   return isLoading ? (


### PR DESCRIPTION
This basically regenerates the JWT Token on refresh of the page which will fix the issue when a user still has a JWT Token of another user in local storage (could happen when kids share browsers). 

Another way to solve this (a bit more efficiently) would be to fix this on the monolith, where we would clear the Local Storage on Logout.