### PR TITLE
Handle no-competitor-limit UI cases

### DIFF
--- a/Frontend/src/pages/register/components/RegistrationRequirements.jsx
+++ b/Frontend/src/pages/register/components/RegistrationRequirements.jsx
@@ -11,10 +11,12 @@ import styles from './requirements.module.scss'
 export default function RegistrationRequirements() {
   const { competitionInfo } = useContext(CompetitionContext)
   const [activeIndex, setActiveIndex] = useState(-1)
-  const handleClick = (e, titleProps) => {
+
+  const handleClick = (_, titleProps) => {
     const { index } = titleProps
     setActiveIndex(activeIndex === index ? -1 : index)
   }
+
   return (
     <div className={styles.requirements}>
       <Header as="h1" attached="top">
@@ -45,13 +47,24 @@ export default function RegistrationRequirements() {
             onClick={handleClick}
           >
             <UiIcon name="dropdown" />
-            {competitionInfo.competitor_limit} person Competitor Limit
+            {competitionInfo.competitor_limit
+              ? `${competitionInfo.competitor_limit} Person Competitor Limit`
+              : 'No Competitor Limit'}
           </Accordion.Title>
           <Accordion.Content active={activeIndex === 1}>
-            <p>
-              Once the competitor Limit has been reached you will be put onto
-              the waiting list.
-            </p>
+            {competitionInfo.competitor_limit ? (
+              <p>
+                Once the competitor limit has been reached you will be put onto
+                the waiting list.
+              </p>
+            ) : (
+              <p>
+                There is no competitor limit, but if this competition has
+                multiple locations then each location may have a separate
+                competitor limit. Please review the other tabs for more
+                information.
+              </p>
+            )}
           </Accordion.Content>
           <Accordion.Title
             active={activeIndex === 2}

--- a/Frontend/src/pages/register/components/RegistrationRequirements.jsx
+++ b/Frontend/src/pages/register/components/RegistrationRequirements.jsx
@@ -25,6 +25,7 @@ export default function RegistrationRequirements() {
           [INSERT ORGANIZER MESSAGE REGARDING REQUIREMENTS]
         </Header.Subheader>
       </Header>
+
       <Segment padded inverted color="orange" attached size="big">
         <Accordion inverted>
           <Accordion.Title
@@ -41,6 +42,7 @@ export default function RegistrationRequirements() {
               <a href="/users/sign_up">here</a> to create one.
             </p>
           </Accordion.Content>
+
           <Accordion.Title
             active={activeIndex === 1}
             index={1}
@@ -66,6 +68,7 @@ export default function RegistrationRequirements() {
               </p>
             )}
           </Accordion.Content>
+
           <Accordion.Title
             active={activeIndex === 2}
             index={2}
@@ -89,6 +92,7 @@ export default function RegistrationRequirements() {
               before this date.`}
             </p>
           </Accordion.Content>
+
           <Accordion.Title
             active={activeIndex === 3}
             index={3}
@@ -104,6 +108,7 @@ export default function RegistrationRequirements() {
           <Accordion.Content active={activeIndex === 3}>
             <p>You can edit your registration until this date.</p>
           </Accordion.Content>
+
           <Accordion.Title
             active={activeIndex === 4}
             index={4}
@@ -130,6 +135,7 @@ export default function RegistrationRequirements() {
                 : 'This competition is free'}
             </p>
           </Accordion.Content>
+
           <Accordion.Title
             active={activeIndex === 5}
             index={5}
@@ -154,6 +160,7 @@ export default function RegistrationRequirements() {
                 : 'Guests attend for free.'}
             </p>
           </Accordion.Content>
+
           {competitionInfo.extra_registration_requirements && (
             <>
               <Accordion.Title

--- a/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
+++ b/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
@@ -186,8 +186,10 @@ export default function RegistrationAdministrationList() {
         />
 
         <Header>
-          Approved registrations ({accepted.length}/
-          {competitionInfo.competitor_limit})
+          Approved registrations ({accepted.length}
+          {competitionInfo.competitor_limit &&
+            `/${competitionInfo.competitor_limit}`}
+          )
         </Header>
         <RegistrationAdministrationTable
           registrations={accepted}

--- a/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
+++ b/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
@@ -171,6 +171,10 @@ export default function RegistrationAdministrationList() {
     [registrations]
   )
 
+  const spotsRemaining = `; ${
+    competitionInfo?.competitor_limit - accepted?.length
+  } spot(s) remaining`
+
   return isLoading ? (
     <LoadingMessage />
   ) : (
@@ -187,8 +191,12 @@ export default function RegistrationAdministrationList() {
 
         <Header>
           Approved registrations ({accepted.length}
-          {competitionInfo.competitor_limit &&
-            `/${competitionInfo.competitor_limit}`}
+          {competitionInfo.competitor_limit && (
+            <>
+              {`/${competitionInfo.competitor_limit}`}
+              {spotsRemaining}
+            </>
+          )}
           )
         </Header>
         <RegistrationAdministrationTable
@@ -199,7 +207,10 @@ export default function RegistrationAdministrationList() {
           selected={selected.accepted}
         />
 
-        <Header> Waitlisted registrations ({waiting.length}) </Header>
+        <Header>
+          Waitlisted registrations ({waiting.length}
+          {competitionInfo.competitor_limit && spotsRemaining})
+        </Header>
         <RegistrationAdministrationTable
           registrations={waiting}
           add={(attendee) => dispatch({ type: 'add-waiting', attendee })}

--- a/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
+++ b/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
@@ -171,6 +171,8 @@ export default function RegistrationAdministrationList() {
     [registrations]
   )
 
+  // some sticky/floating bar somewhere with totals/info would be better
+  // than putting this in the table headers which scroll out of sight
   const spotsRemaining = `; ${
     competitionInfo?.competitor_limit - accepted?.length
   } spot(s) remaining`

--- a/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
+++ b/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
@@ -141,6 +141,7 @@ const truncateComment = (comment) =>
 
 export default function RegistrationAdministrationList() {
   const { competitionInfo } = useContext(CompetitionContext)
+
   const {
     isLoading,
     data: registrations,
@@ -157,6 +158,7 @@ export default function RegistrationAdministrationList() {
       setMessage(err.message, 'error')
     },
   })
+
   const [selected, dispatch] = useReducer(reducer, {
     pending: [],
     accepted: [],
@@ -168,6 +170,7 @@ export default function RegistrationAdministrationList() {
     () => partitionRegistrations(registrations ?? []),
     [registrations]
   )
+
   return isLoading ? (
     <LoadingMessage />
   ) : (
@@ -181,6 +184,7 @@ export default function RegistrationAdministrationList() {
           competition_id={competitionInfo.id}
           selected={selected.pending}
         />
+
         <Header>
           Approved registrations ({accepted.length}/
           {competitionInfo.competitor_limit})
@@ -192,6 +196,7 @@ export default function RegistrationAdministrationList() {
           competition_id={competitionInfo.id}
           selected={selected.accepted}
         />
+
         <Header> Waitlisted registrations ({waiting.length}) </Header>
         <RegistrationAdministrationTable
           registrations={waiting}
@@ -200,6 +205,7 @@ export default function RegistrationAdministrationList() {
           competition_id={competitionInfo.id}
           selected={selected.waiting}
         />
+
         <Header> Cancelled registrations ({cancelled.length}) </Header>
         <RegistrationAdministrationTable
           registrations={cancelled}
@@ -211,6 +217,7 @@ export default function RegistrationAdministrationList() {
           selected={selected.cancelled}
         />
       </div>
+
       <RegistrationActions
         selected={selected}
         refresh={async () => {
@@ -231,6 +238,7 @@ function RegistrationAdministrationTable({
   selected,
 }) {
   const { competitionInfo } = useContext(CompetitionContext)
+
   return (
     <Table striped textAlign="left">
       <Table.Header>
@@ -264,6 +272,7 @@ function RegistrationAdministrationTable({
           <Table.HeaderCell>Email</Table.HeaderCell>
         </Table.Row>
       </Table.Header>
+
       <Table.Body>
         {registrations.length > 0 ? (
           registrations.map((registration) => {


### PR DESCRIPTION
Also added some more information to the registration table headers. Though as noted, some kind of sticky/floating box somewhere, which always stays in sight, would probably be a better solution in the future.

This will create more conflicts with the new design PR, since the accordion was completely redone there.

I don't think the codebase has enough blank lines separating chunks of code. :smiley: 