### PR TITLE
Refactor Registration Admin selected-rows reducer

### DIFF
--- a/Frontend/src/api/helper/context/permission_context.ts
+++ b/Frontend/src/api/helper/context/permission_context.ts
@@ -5,10 +5,12 @@ interface PermissionsContext {
   permissions?: Permissions
   canAdminCompetition: boolean
   canAttendCompetition: boolean
+  isOrganizerOrDelegate: boolean
 }
 
 export const PermissionsContext = createContext<PermissionsContext>({
   permissions: undefined,
   canAdminCompetition: false,
   canAttendCompetition: false,
+  isOrganizerOrDelegate: false,
 })

--- a/Frontend/src/pages/registration_administration/components/RegistrationActions.jsx
+++ b/Frontend/src/pages/registration_administration/components/RegistrationActions.jsx
@@ -3,6 +3,7 @@ import { UiIcon } from '@thewca/wca-components'
 import React, { useContext } from 'react'
 import { Button } from 'semantic-ui-react'
 import { CompetitionContext } from '../../../api/helper/context/competition_context'
+import { PermissionsContext } from '../../../api/helper/context/permission_context'
 import { updateRegistration } from '../../../api/registration/patch/update_registration'
 import { setMessage } from '../../../ui/events/messages'
 import styles from './actions.module.scss'
@@ -32,6 +33,7 @@ export default function RegistrationActions({
   registrations,
 }) {
   const { competitionInfo } = useContext(CompetitionContext)
+  const { isOrganizerOrDelegate } = useContext(PermissionsContext)
 
   const selectedCount = Object.values(partitionedSelected).reduce(
     (sum, part) => sum + part.length,
@@ -44,9 +46,6 @@ export default function RegistrationActions({
   const anyApprovable = accepted.length < selectedCount
   const anyCancellable = cancelled.length < selectedCount
   const anyWaitlistable = waiting.length < selectedCount
-
-  // TODO: mirror backend conditions, ie only organizers and delegates of the competition(?)
-  const canChangeStatuses = true
 
   const { mutate: updateRegistrationMutation } = useMutation({
     mutationFn: updateRegistration,
@@ -110,7 +109,7 @@ export default function RegistrationActions({
           </a>
         </Button>
 
-        {canChangeStatuses && (
+        {isOrganizerOrDelegate && (
           <>
             {anyApprovable && (
               <Button

--- a/Frontend/src/pages/registration_administration/components/RegistrationActions.jsx
+++ b/Frontend/src/pages/registration_administration/components/RegistrationActions.jsx
@@ -45,6 +45,9 @@ export default function RegistrationActions({
   const anyCancellable = cancelled.length < selectedCount
   const anyWaitlistable = waiting.length < selectedCount
 
+  // TODO: mirror backend conditions, ie only organizers and delegates of the competition(?)
+  const canChangeStatuses = true
+
   const { mutate: updateRegistrationMutation } = useMutation({
     mutationFn: updateRegistration,
     onError: (data) => {
@@ -107,50 +110,63 @@ export default function RegistrationActions({
           </a>
         </Button>
 
-        {anyApprovable && (
-          <Button
-            positive
-            onClick={() =>
-              changeStatus([...pending, ...cancelled, ...waiting], 'accepted')
-            }
-          >
-            <UiIcon name="check" /> Approve
-          </Button>
-        )}
+        {canChangeStatuses && (
+          <>
+            {anyApprovable && (
+              <Button
+                positive
+                onClick={() =>
+                  changeStatus(
+                    [...pending, ...cancelled, ...waiting],
+                    'accepted'
+                  )
+                }
+              >
+                <UiIcon name="check" /> Approve
+              </Button>
+            )}
 
-        {anyRejectable && (
-          <Button
-            onClick={() =>
-              changeStatus([...accepted, ...cancelled, ...waiting], 'pending')
-            }
-          >
-            <UiIcon name="times" /> Move to Pending
-          </Button>
-        )}
+            {anyRejectable && (
+              <Button
+                onClick={() =>
+                  changeStatus(
+                    [...accepted, ...cancelled, ...waiting],
+                    'pending'
+                  )
+                }
+              >
+                <UiIcon name="times" /> Move to Pending
+              </Button>
+            )}
 
-        {anyWaitlistable && (
-          <Button
-            color="yellow"
-            onClick={() =>
-              changeStatus(
-                [...pending, ...cancelled, ...accepted],
-                'waiting_list'
-              )
-            }
-          >
-            <UiIcon name="hourglass" /> Move to Waiting List
-          </Button>
-        )}
+            {anyWaitlistable && (
+              <Button
+                color="yellow"
+                onClick={() =>
+                  changeStatus(
+                    [...pending, ...cancelled, ...accepted],
+                    'waiting_list'
+                  )
+                }
+              >
+                <UiIcon name="hourglass" /> Move to Waiting List
+              </Button>
+            )}
 
-        {anyCancellable && (
-          <Button
-            negative
-            onClick={() =>
-              changeStatus([...pending, ...accepted, ...waiting], 'cancelled')
-            }
-          >
-            <UiIcon name="trash" /> Cancel Registration
-          </Button>
+            {anyCancellable && (
+              <Button
+                negative
+                onClick={() =>
+                  changeStatus(
+                    [...pending, ...accepted, ...waiting],
+                    'cancelled'
+                  )
+                }
+              >
+                <UiIcon name="trash" /> Cancel Registration
+              </Button>
+            )}
+          </>
         )}
       </Button.Group>
     )

--- a/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
+++ b/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
@@ -11,100 +11,32 @@ import LoadingMessage from '../../../ui/messages/loadingMessage'
 import styles from './list.module.scss'
 import RegistrationActions from './RegistrationActions'
 
-// Currently it is at the developer's discretion to make sure
-// an attendee is added to the right list.
-// One Solution would be to keep the registrations state as
-// the source of truth and partition as needed
-const reducer = (state, action) => {
-  const { type, attendee } = action
-  // Make sure no one adds an attendee twice
-  if (
-    type.startsWith('add') &&
-    [
-      ...state.waiting,
-      ...state.accepted,
-      ...state.cancelled,
-      ...state.pending,
-    ].includes(attendee)
-  ) {
-    return state
-  }
+const selectedReducer = (state, action) => {
+  let newState = [...state]
+
+  const { type, attendee, attendees } = action
+  const idList = attendees || [attendee]
+
   switch (type) {
-    case 'add-pending':
-      return {
-        pending: [...state.pending, attendee],
-        accepted: state.accepted,
-        cancelled: state.cancelled,
-        waiting: state.waiting,
-      }
-    case 'remove-pending':
-      return {
-        pending: state.pending.filter(
-          (selectedAttendee) => selectedAttendee !== attendee
-        ),
-        accepted: state.accepted,
-        cancelled: state.cancelled,
-        waiting: state.waiting,
-      }
-    case 'add-waiting':
-      return {
-        waiting: [...state.waiting, attendee],
-        accepted: state.accepted,
-        cancelled: state.cancelled,
-        pending: state.pending,
-      }
-    case 'remove-waiting':
-      return {
-        waiting: state.waiting.filter(
-          (selectedAttendee) => selectedAttendee !== attendee
-        ),
-        accepted: state.accepted,
-        cancelled: state.cancelled,
-        pending: state.pending,
-      }
-    case 'add-accepted':
-      return {
-        accepted: [...state.accepted, attendee],
-        waiting: state.waiting,
-        cancelled: state.cancelled,
-        pending: state.pending,
-      }
-    case 'remove-accepted':
-      return {
-        accepted: state.accepted.filter(
-          (selectedAttendee) => selectedAttendee !== attendee
-        ),
-        waiting: state.waiting,
-        cancelled: state.cancelled,
-        pending: state.pending,
-      }
-    case 'add-cancelled':
-      return {
-        cancelled: [...state.cancelled, attendee],
-        accepted: state.accepted,
-        waiting: state.waiting,
-        pending: state.pending,
-      }
-    case 'remove-cancelled':
-      return {
-        cancelled: state.cancelled.filter(
-          (selectedAttendee) => selectedAttendee !== attendee
-        ),
-        accepted: state.accepted,
-        waiting: state.waiting,
-        pending: state.pending,
-      }
-    case 'clear-selected': {
-      return {
-        waiting: [],
-        accepted: [],
-        cancelled: [],
-        pending: [],
-      }
-    }
+    case 'add':
+      idList.forEach((id) => {
+        // Make sure no one adds an attendee twice
+        if (!newState.includes(id)) newState.push(id)
+      })
+      break
+
+    case 'remove':
+      newState = newState.filter((id) => !idList.includes(id))
+      break
+
+    case 'clear-selected':
+      return []
+
     default:
       throw new Error('Unknown action.')
   }
+
+  return newState
 }
 
 const partitionRegistrations = (registrations) => {
@@ -159,17 +91,36 @@ export default function RegistrationAdministrationList() {
     },
   })
 
-  const [selected, dispatch] = useReducer(reducer, {
-    pending: [],
-    accepted: [],
-    cancelled: [],
-    waiting: [],
-  })
-
   const { waiting, accepted, cancelled, pending } = useMemo(
     () => partitionRegistrations(registrations ?? []),
     [registrations]
   )
+
+  const [selected, dispatch] = useReducer(selectedReducer, [])
+  const partitionedSelected = useMemo(
+    () => ({
+      pending: selected.filter((id) =>
+        pending.some((reg) => id === reg.user.id)
+      ),
+      waiting: selected.filter((id) =>
+        waiting.some((reg) => id === reg.user.id)
+      ),
+      accepted: selected.filter((id) =>
+        accepted.some((reg) => id === reg.user.id)
+      ),
+      cancelled: selected.filter((id) =>
+        cancelled.some((reg) => id === reg.user.id)
+      ),
+    }),
+    [selected, pending, waiting, accepted, cancelled]
+  )
+
+  function select(attendees) {
+    dispatch({ type: 'add', attendees })
+  }
+  function unselect(attendees) {
+    dispatch({ type: 'remove', attendees })
+  }
 
   // some sticky/floating bar somewhere with totals/info would be better
   // than putting this in the table headers which scroll out of sight
@@ -185,10 +136,10 @@ export default function RegistrationAdministrationList() {
         <Header> Pending registrations ({pending.length}) </Header>
         <RegistrationAdministrationTable
           registrations={pending}
-          add={(attendee) => dispatch({ type: 'add-pending', attendee })}
-          remove={(attendee) => dispatch({ type: 'remove-pending', attendee })}
+          select={select}
+          unselect={unselect}
           competition_id={competitionInfo.id}
-          selected={selected.pending}
+          selected={partitionedSelected.pending}
         />
 
         <Header>
@@ -203,10 +154,10 @@ export default function RegistrationAdministrationList() {
         </Header>
         <RegistrationAdministrationTable
           registrations={accepted}
-          add={(attendee) => dispatch({ type: 'add-accepted', attendee })}
-          remove={(attendee) => dispatch({ type: 'remove-accepted', attendee })}
+          select={select}
+          unselect={unselect}
           competition_id={competitionInfo.id}
-          selected={selected.accepted}
+          selected={partitionedSelected.accepted}
         />
 
         <Header>
@@ -215,26 +166,24 @@ export default function RegistrationAdministrationList() {
         </Header>
         <RegistrationAdministrationTable
           registrations={waiting}
-          add={(attendee) => dispatch({ type: 'add-waiting', attendee })}
-          remove={(attendee) => dispatch({ type: 'remove-waiting', attendee })}
+          select={select}
+          unselect={unselect}
           competition_id={competitionInfo.id}
-          selected={selected.waiting}
+          selected={partitionedSelected.waiting}
         />
 
-        <Header> Cancelled registrations ({cancelled.length}) </Header>
+        <Header>Cancelled registrations ({cancelled.length})</Header>
         <RegistrationAdministrationTable
           registrations={cancelled}
-          add={(attendee) => dispatch({ type: 'add-cancelled', attendee })}
-          remove={(attendee) =>
-            dispatch({ type: 'remove-cancelled', attendee })
-          }
+          select={select}
+          unselect={unselect}
           competition_id={competitionInfo.id}
-          selected={selected.cancelled}
+          selected={partitionedSelected.cancelled}
         />
       </div>
 
       <RegistrationActions
-        selected={selected}
+        partitionedSelected={partitionedSelected}
         refresh={async () => {
           await refetch()
           dispatch({ type: 'clear-selected' })
@@ -247,8 +196,8 @@ export default function RegistrationAdministrationList() {
 
 function RegistrationAdministrationTable({
   registrations,
-  add,
-  remove,
+  select,
+  unselect,
   competition_id,
   selected,
 }) {
@@ -259,15 +208,16 @@ function RegistrationAdministrationTable({
       <Table.Header>
         <Table.Row>
           <Table.HeaderCell>
-            <Checkbox
-              onChange={(_, data) => {
-                registrations.forEach((registration) =>
+            {registrations.length > 0 && (
+              <Checkbox
+                checked={registrations.length === selected.length}
+                onChange={(_, data) => {
                   data.checked
-                    ? add(registration.user.id)
-                    : remove(registration.user.id)
-                )
-              }}
-            />
+                    ? select(registrations.map(({ user }) => user.id))
+                    : unselect(registrations.map(({ user }) => user.id))
+                }}
+              />
+            )}
           </Table.HeaderCell>
           <Table.HeaderCell />
           <Table.HeaderCell>WCA ID</Table.HeaderCell>
@@ -299,11 +249,9 @@ function RegistrationAdministrationTable({
                 <Table.Cell>
                   <Checkbox
                     onChange={(_, data) => {
-                      if (data.checked) {
-                        add(registration.user.id)
-                      } else {
-                        remove(registration.user.id)
-                      }
+                      data.checked
+                        ? select([registration.user.id])
+                        : unselect([registration.user.id])
                     }}
                     checked={selected.includes(registration.user.id)}
                   />
@@ -316,14 +264,12 @@ function RegistrationAdministrationTable({
                   </Link>
                 </Table.Cell>
                 <Table.Cell>
-                  {registration.user.wca_id ? (
+                  {registration.user.wca_id && (
                     <a
                       href={`https://www.worldcubeassociation.org/persons/${registration.user.wca_id}`}
                     >
                       {registration.user.wca_id}
                     </a>
-                  ) : (
-                    ''
                   )}
                 </Table.Cell>
                 <Table.Cell>{registration.user.name}</Table.Cell>
@@ -345,13 +291,14 @@ function RegistrationAdministrationTable({
                     }
                   />
                 </Table.Cell>
+
                 {competitionInfo['using_stripe_payments?'] && (
                   <>
                     <Table.Cell>
                       {registration.payment.payment_status ?? 'not paid'}
                     </Table.Cell>
                     <Table.Cell>
-                      {registration.payment.updated_at ? (
+                      {registration.payment.updated_at && (
                         <Popup
                           content={new Date(
                             registration.payment.updated_at
@@ -364,8 +311,6 @@ function RegistrationAdministrationTable({
                             </span>
                           }
                         />
-                      ) : (
-                        ''
                       )}
                     </Table.Cell>
                   </>

--- a/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
+++ b/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
@@ -115,12 +115,8 @@ export default function RegistrationAdministrationList() {
     [selected, pending, waiting, accepted, cancelled]
   )
 
-  function select(attendees) {
-    dispatch({ type: 'add', attendees })
-  }
-  function unselect(attendees) {
-    dispatch({ type: 'remove', attendees })
-  }
+  const select = (attendees) => dispatch({ type: 'add', attendees })
+  const unselect = (attendees) => dispatch({ type: 'remove', attendees })
 
   // some sticky/floating bar somewhere with totals/info would be better
   // than putting this in the table headers which scroll out of sight
@@ -212,9 +208,11 @@ function RegistrationAdministrationTable({
               <Checkbox
                 checked={registrations.length === selected.length}
                 onChange={(_, data) => {
-                  data.checked
-                    ? select(registrations.map(({ user }) => user.id))
-                    : unselect(registrations.map(({ user }) => user.id))
+                  if (data.checked) {
+                    select(registrations.map(({ user }) => user.id))
+                  } else {
+                    unselect(registrations.map(({ user }) => user.id))
+                  }
                 }}
               />
             )}
@@ -249,9 +247,11 @@ function RegistrationAdministrationTable({
                 <Table.Cell>
                   <Checkbox
                     onChange={(_, data) => {
-                      data.checked
-                        ? select([registration.user.id])
-                        : unselect([registration.user.id])
+                      if (data.checked) {
+                        select([registration.user.id])
+                      } else {
+                        unselect([registration.user.id])
+                      }
                     }}
                     checked={selected.includes(registration.user.id)}
                   />

--- a/Frontend/src/ui/providers/PermissionsProvider.jsx
+++ b/Frontend/src/ui/providers/PermissionsProvider.jsx
@@ -30,6 +30,9 @@ export default function PermissionsProvider({ children }) {
           permissions?.can_administer_competitions.scope.includes(
             competitionInfo.id
           ),
+        isOrganizerOrDelegate: competitionInfo.organizers
+          .concat(competitionInfo.delegates)
+          .some((organizer) => organizer.id === user.id),
       }}
     >
       {children}


### PR DESCRIPTION
Avoids storing redundant information in state about which table the selected attendee is in. This technically wasn't causing issues, but future code changes had the possibility of introducing bugs.

Also changed the checkboxes on the header rows to match the state of the rows below (ie is checked if and only if all the rows are checked), and omitted them when their respective table is empty.

Plus I started adding the functionality to hide the changing-status buttons when the user doesn't have that ability - @FinnIckler if you could finish that off that would be great, since you're familiar with who should have what permissions. Or it can be saved for a later ticket.