### PR TITLE
Hide page tabs 'More' when empty & move registration steps down

### DIFF
--- a/Frontend/src/pages/register/index.jsx
+++ b/Frontend/src/pages/register/index.jsx
@@ -43,23 +43,6 @@ export default function Register() {
         <div>
           {canAttendCompetition ? (
             <>
-              <Transition
-                visible={showRegisterSteps}
-                duration={500}
-                animation="scale"
-              >
-                <Segment padded basic>
-                  <Button
-                    floated="right"
-                    icon
-                    basic
-                    onClick={() => setShowRegisterSteps(false)}
-                  >
-                    <Icon name="close" />
-                  </Button>
-                  <StepPanel />
-                </Segment>
-              </Transition>
               <Segment padded attached raised>
                 <Message warning>
                   *Insert Potential organizer announcement or memo for users to
@@ -206,6 +189,24 @@ export default function Register() {
                   </Button>
                 </Transition>
               </Segment>
+
+              <Transition
+                visible={showRegisterSteps}
+                duration={500}
+                animation="scale"
+              >
+                <Segment padded basic>
+                  <Button
+                    floated="right"
+                    icon
+                    basic
+                    onClick={() => setShowRegisterSteps(false)}
+                  >
+                    <Icon name="close" />
+                  </Button>
+                  <StepPanel />
+                </Segment>
+              </Transition>
             </>
           ) : (
             <PermissionMessage>

--- a/Frontend/src/ui/PageTabs.jsx
+++ b/Frontend/src/ui/PageTabs.jsx
@@ -103,8 +103,16 @@ export default function PageTabs() {
     )
   }, [competitionInfo.tabs, location])
 
+  const hasCustomTabs = competitionInfo.tabs.length > 0
+
   return (
-    <Menu attached fluid widths={menuItems.length + 1} size="huge" stackable>
+    <Menu
+      attached
+      fluid
+      widths={menuItems.length + (hasCustomTabs ? 1 : 0)}
+      size="huge"
+      stackable
+    >
       {menuItems.map((menuConfig) => (
         <Menu.Item
           key={menuConfig.key}
@@ -125,23 +133,26 @@ export default function PageTabs() {
           {menuConfig.label}
         </Menu.Item>
       ))}
-      <Dropdown item text="More" className={customTabActive ? 'active' : ''}>
-        <Dropdown.Menu>
-          {competitionInfo.tabs.map((competitionTab) => (
-            <Dropdown.Item
-              key={competitionTab.id}
-              onClick={() =>
-                navigate(
-                  `${BASE_ROUTE}/${competitionInfo.id}/tabs/${competitionTab.id}`
-                )
-              }
-              active={pathMatch(competitionTab.id, location.pathname)}
-            >
-              {competitionTab.name}
-            </Dropdown.Item>
-          ))}
-        </Dropdown.Menu>
-      </Dropdown>
+
+      {hasCustomTabs && (
+        <Dropdown item text="More" className={customTabActive ? 'active' : ''}>
+          <Dropdown.Menu>
+            {competitionInfo.tabs.map((competitionTab) => (
+              <Dropdown.Item
+                key={competitionTab.id}
+                onClick={() =>
+                  navigate(
+                    `${BASE_ROUTE}/${competitionInfo.id}/tabs/${competitionTab.id}`
+                  )
+                }
+                active={pathMatch(competitionTab.id, location.pathname)}
+              >
+                {competitionTab.name}
+              </Dropdown.Item>
+            ))}
+          </Dropdown.Menu>
+        </Dropdown>
+      )}
     </Menu>
   )
 }

--- a/Frontend/src/ui/PageTabs.jsx
+++ b/Frontend/src/ui/PageTabs.jsx
@@ -6,35 +6,6 @@ import { CompetitionContext } from '../api/helper/context/competition_context'
 import { PermissionsContext } from '../api/helper/context/permission_context'
 import { BASE_ROUTE } from '../routes'
 
-function pathMatch(name, pathname) {
-  const registerExpression = /\/competitions\/v2\/[a-zA-Z0-9]+\/register/
-  const registrationsExpression =
-    /\/competitions\/v2\/[a-zA-Z0-9]+\/registrations\/edit/
-  const competitorsExpression =
-    /\/competitions\/v2\/[a-zA-Z0-9]+\/registrations\/?$/
-  const eventsExpressions = /\/competitions\/v2\/[a-zA-Z0-9]+\/events/
-  const scheduleExpressions = /\/competitions\/v2\/[a-zA-Z0-9]+\/schedule/
-  const infoExpression = /\/competitions\/v2\/[a-zA-Z0-9]+\/?$/
-  switch (name) {
-    case 'register':
-      return registerExpression.test(pathname)
-    case 'registrations':
-      return registrationsExpression.test(pathname)
-    case 'competitors':
-      return competitorsExpression.test(pathname)
-    case 'schedule':
-      return scheduleExpressions.test(pathname)
-    case 'info':
-      return infoExpression.test(pathname)
-    case 'events':
-      return eventsExpressions.test(pathname)
-    default: {
-      // We are in a custom tab
-      return name === Number.parseInt(pathname.split('/tabs/')[1], 10)
-    }
-  }
-}
-
 export default function PageTabs() {
   const { competitionInfo } = useContext(CompetitionContext)
   const { canAdminCompetition } = useContext(PermissionsContext)
@@ -46,48 +17,23 @@ export default function PageTabs() {
     const optionalTabs = []
 
     if (competitionInfo.use_wca_registration) {
-      optionalTabs.push({
-        key: 'register',
-        icon: 'sign in alt',
-        label: 'Register',
-      })
+      optionalTabs.push(registerMenuConfig)
     }
     if (canAdminCompetition) {
-      optionalTabs.push({
-        key: 'registrations',
-        route: 'registrations/edit',
-        icon: 'list ul',
-        label: 'Registrations',
-      })
+      optionalTabs.push(registrationsMenuConfig)
     }
     if (new Date(competitionInfo.registration_open) < Date.now()) {
-      optionalTabs.push({
-        key: 'competitors',
-        route: 'registrations',
-        icon: 'users',
-        label: 'Competitors',
-      })
+      optionalTabs.push(competitorsMenuConfig)
     }
 
+    const eventTabIcon =
+      competitionInfo.main_event_id ?? competitionInfo.event_ids[0]
+
     return [
-      {
-        key: 'info',
-        route: '',
-        icon: 'info',
-        label: 'General Info',
-      },
+      generalInfoMenuConfig,
       ...optionalTabs,
-      {
-        key: 'events',
-        icon: competitionInfo.main_event_id ?? competitionInfo.event_ids[0],
-        label: 'Events',
-        cubing: true,
-      },
-      {
-        key: 'schedule',
-        icon: 'calendar',
-        label: 'Schedule',
-      },
+      eventsMenuConfig(eventTabIcon),
+      scheduleMenuConfig,
     ]
   }, [
     competitionInfo.use_wca_registration,
@@ -155,4 +101,68 @@ export default function PageTabs() {
       )}
     </Menu>
   )
+}
+
+function pathMatch(name, pathname) {
+  const registerExpression = /\/competitions\/v2\/[a-zA-Z0-9]+\/register/
+  const registrationsExpression =
+    /\/competitions\/v2\/[a-zA-Z0-9]+\/registrations\/edit/
+  const competitorsExpression =
+    /\/competitions\/v2\/[a-zA-Z0-9]+\/registrations\/?$/
+  const eventsExpressions = /\/competitions\/v2\/[a-zA-Z0-9]+\/events/
+  const scheduleExpressions = /\/competitions\/v2\/[a-zA-Z0-9]+\/schedule/
+  const infoExpression = /\/competitions\/v2\/[a-zA-Z0-9]+\/?$/
+  switch (name) {
+    case 'register':
+      return registerExpression.test(pathname)
+    case 'registrations':
+      return registrationsExpression.test(pathname)
+    case 'competitors':
+      return competitorsExpression.test(pathname)
+    case 'schedule':
+      return scheduleExpressions.test(pathname)
+    case 'info':
+      return infoExpression.test(pathname)
+    case 'events':
+      return eventsExpressions.test(pathname)
+    default: {
+      // We are in a custom tab
+      return name === Number.parseInt(pathname.split('/tabs/')[1], 10)
+    }
+  }
+}
+
+const registerMenuConfig = {
+  key: 'register',
+  icon: 'sign in alt',
+  label: 'Register',
+}
+const registrationsMenuConfig = {
+  key: 'registrations',
+  route: 'registrations/edit',
+  icon: 'list ul',
+  label: 'Registrations',
+}
+const competitorsMenuConfig = {
+  key: 'competitors',
+  route: 'registrations',
+  icon: 'users',
+  label: 'Competitors',
+}
+const generalInfoMenuConfig = {
+  key: 'info',
+  route: '',
+  icon: 'info',
+  label: 'General Info',
+}
+const eventsMenuConfig = (icon) => ({
+  key: 'events',
+  icon,
+  label: 'Events',
+  cubing: true,
+})
+const scheduleMenuConfig = {
+  key: 'schedule',
+  icon: 'calendar',
+  label: 'Schedule',
 }


### PR DESCRIPTION
Sorry for including 2 separate things in 1 PR.

The tabs are still not perfect - they're good on large and small screens but on medium screens they overflow and overlap each other.

Putting the registration steps below the registration info seems logical to me, and also prevents most of the jumping around. The fade transitions we have are nice, and they would be even nicer if the space they take up gradually expanded/contracted, rather than jumping before/after the transition. But I'm not sure how to cleanly do that (only idea is to add a transition to the `min-height` of the container, which kind of requires knowing the height in advance?).