### PR TITLE
Registrations table expandable columns

### DIFF
--- a/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
+++ b/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { FlagIcon, UiIcon } from '@thewca/wca-components'
+import { CubingIcon, FlagIcon, UiIcon } from '@thewca/wca-components'
 import React, { useContext, useMemo, useReducer } from 'react'
 import { Link } from 'react-router-dom'
 import { Checkbox, Form, Header, Icon, Popup, Table } from 'semantic-ui-react'
@@ -282,7 +282,7 @@ function RegistrationAdministrationTable({
           {events ? (
             competitionInfo.event_ids.map((eventId) => (
               <Table.HeaderCell key={`event-${eventId}`}>
-                {eventId}
+                <CubingIcon event={eventId} size={'1x'} selected />
               </Table.HeaderCell>
             ))
           ) : (
@@ -371,8 +371,20 @@ function TableRow({
       <Table.Cell>{name}</Table.Cell>
 
       <Table.Cell>
-        <FlagIcon iso2={country.iso2} />
-        {region && country.name}
+        {region ? (
+          <>
+            <FlagIcon iso2={country.iso2} /> {region && country.name}
+          </>
+        ) : (
+          <Popup
+            content={country.name}
+            trigger={
+              <span>
+                <FlagIcon iso2={country.iso2} />
+              </span>
+            }
+          />
+        )}
       </Table.Cell>
 
       <Table.Cell>
@@ -401,28 +413,56 @@ function TableRow({
       {events ? (
         competitionInfo.event_ids.map((eventId) => (
           <Table.Cell key={`event-${eventId}`}>
-            {event_ids.includes(eventId) && 'Y'}
+            {event_ids.includes(eventId) && (
+              <CubingIcon event={eventId} size="1x" selected />
+            )}
           </Table.Cell>
         ))
       ) : (
-        <Table.Cell>{event_ids.length}</Table.Cell>
+        <Table.Cell>
+          <Popup
+            content={event_ids.map((eventId) => (
+              <CubingIcon key={eventId} event={eventId} size="3x" selected />
+            ))}
+            trigger={<span>{event_ids.length}</span>}
+          />
+        </Table.Cell>
       )}
 
       <Table.Cell>{registration.guests}</Table.Cell>
 
       {comments && (
         <>
-          <Table.Cell title={comment}>{truncateComment(comment)}</Table.Cell>
+          <Table.Cell>
+            <Popup
+              content={comment}
+              trigger={<span>{truncateComment(comment)}</span>}
+            />
+          </Table.Cell>
 
-          <Table.Cell title={admin_comment}>
-            {truncateComment(admin_comment)}
+          <Table.Cell>
+            <Popup
+              content={admin_comment}
+              trigger={<span>{truncateComment(admin_comment)}</span>}
+            />
           </Table.Cell>
         </>
       )}
 
       <Table.Cell>
         <a href={`mailto:${emailAddress}`}>
-          {email ? emailAddress : <UiIcon name="mail" />}
+          {email ? (
+            emailAddress
+          ) : (
+            <Popup
+              content={emailAddress}
+              trigger={
+                <span>
+                  <UiIcon name="mail" />
+                </span>
+              }
+            />
+          )}
         </a>{' '}
         <Icon link onClick={copyEmail} name="copy" title="Copy Email Address" />
       </Table.Cell>

--- a/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
+++ b/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
@@ -82,11 +82,11 @@ const initialExpandedColumns = {
 const columnReducer = (state, action) => {
   if (action.type === 'reset') {
     return initialExpandedColumns
-  } else if (Object.keys(expandableColumns).includes(action.column)) {
-    return { ...state, [action.column]: !state[action.column] }
-  } else {
-    return state
   }
+  if (Object.keys(expandableColumns).includes(action.column)) {
+    return { ...state, [action.column]: !state[action.column] }
+  }
+  return state
 }
 
 // Semantic Table only allows truncating _all_ columns in a table in
@@ -283,7 +283,7 @@ function RegistrationAdministrationTable({
           {events ? (
             competitionInfo.event_ids.map((eventId) => (
               <Table.HeaderCell key={`event-${eventId}`}>
-                <CubingIcon event={eventId} size={'1x'} selected />
+                <CubingIcon event={eventId} size="1x" selected />
               </Table.HeaderCell>
             ))
           ) : (

--- a/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
+++ b/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
@@ -248,7 +248,7 @@ function RegistrationAdministrationTable({
   selected,
 }) {
   const { competitionInfo } = useContext(CompetitionContext)
-  const { events, comments } = columnsExpanded
+  const { dob, events, comments } = columnsExpanded
 
   return (
     <Table striped textAlign="left">
@@ -271,6 +271,7 @@ function RegistrationAdministrationTable({
           <Table.HeaderCell />
           <Table.HeaderCell>WCA ID</Table.HeaderCell>
           <Table.HeaderCell>Name</Table.HeaderCell>
+          {dob && <Table.HeaderCell>DOB</Table.HeaderCell>}
           <Table.HeaderCell>Region</Table.HeaderCell>
           <Table.HeaderCell>Registered on</Table.HeaderCell>
           {competitionInfo['using_stripe_payments?'] && (
@@ -335,13 +336,15 @@ function TableRow({
   isSelected,
   onCheckboxChange,
 }) {
-  const { region, events, email, comments } = columnsExpanded
+  const { dob: dobCol, region, events, comments, email } = columnsExpanded
   const { id, wca_id, name, country } = registration.user
   const { registered_on, event_ids, comment, admin_comment } =
     registration.competing
   const { payment_status, updated_at } = registration.payment
   // TODO: get actual email
   const emailAddress = `${registration.user_id}@worldcubeassociation.org`
+  // TODO: get actual dob
+  const dob = new Date()
 
   const { competitionInfo, competition_id } = useContext(CompetitionContext)
 
@@ -369,6 +372,8 @@ function TableRow({
       </Table.Cell>
 
       <Table.Cell>{name}</Table.Cell>
+
+      {dobCol && <Table.Cell>{dob.toLocaleDateString()}</Table.Cell>}
 
       <Table.Cell>
         {region ? (


### PR DESCRIPTION
The event icons have black popups while everything else has white :\

The emails and DOBs are dummy data, will need a separate PR for the backend to provide those.

The table width is obviously an issue, ideally it should be able to use the full screen width. That should probably be done once the UI is more stable though.

See video on slack.