### PR TITLE
Refactor Schedule and split per-venue

### DIFF
--- a/Frontend/src/pages/schedule/index.jsx
+++ b/Frontend/src/pages/schedule/index.jsx
@@ -22,6 +22,13 @@ const activitiesByDate = (activities, date) => {
   )
 }
 
+const getShortTime = (date, timeZone) => {
+  return new Date(date).toLocaleTimeString([], {
+    timeStyle: 'short',
+    timeZone,
+  })
+}
+
 export default function Schedule() {
   const { competitionInfo } = useContext(CompetitionContext)
 
@@ -55,7 +62,7 @@ export default function Schedule() {
           date
         )
         const rounds = wcif.events.flatMap((events) => events.rounds)
-        const rooms = wcif.schedule.venues.flatMap((venue) => venue.rooms)
+        const venues = wcif.schedule.venues
 
         return (
           <ScheduleOnDate
@@ -63,7 +70,7 @@ export default function Schedule() {
             date={date}
             activities={activitiesForDay}
             rounds={rounds}
-            rooms={rooms}
+            venues={venues}
           />
         )
       })}
@@ -71,10 +78,11 @@ export default function Schedule() {
   )
 }
 
-function ScheduleOnDate({ date, activities, rounds, rooms }) {
+function ScheduleOnDate({ date, activities, rounds, venues }) {
   const sortedActivities = activities.sort(
     (a, b) => new Date(a.startTime) > new Date(b.startTime)
   )
+  const rooms = venues.flatMap((venue) => venue.rooms)
 
   return (
     <Segment basic>
@@ -91,6 +99,8 @@ function ScheduleOnDate({ date, activities, rounds, rooms }) {
                 (ac) => ac.activityCode === activity.activityCode
               )
             )
+            const venue = venues.find((venue) => venue.rooms.includes(room))
+            const timeZone = venue.timezone
 
             return (
               <ScheduleActivityRow
@@ -98,6 +108,7 @@ function ScheduleOnDate({ date, activities, rounds, rooms }) {
                 activity={activity}
                 round={round}
                 room={room}
+                timeZone={timeZone}
               />
             )
           })}
@@ -124,15 +135,15 @@ function ScheduleHeaderRow() {
   )
 }
 
-function ScheduleActivityRow({ activity, round, room }) {
+function ScheduleActivityRow({ activity, round, room, timeZone }) {
   // note: round/room may be undefined for custom activities like lunch
 
   const { name, startTime, endTime } = activity
 
   return (
     <Table.Row>
-      <Table.Cell>{moment(startTime).format('HH:mm')}</Table.Cell>
-      <Table.Cell>{moment(endTime).format('HH:mm')}</Table.Cell>
+      <Table.Cell>{getShortTime(startTime, timeZone)}</Table.Cell>
+      <Table.Cell>{getShortTime(endTime, timeZone)}</Table.Cell>
 
       <Table.Cell>{name}</Table.Cell>
 

--- a/Frontend/src/pages/schedule/index.jsx
+++ b/Frontend/src/pages/schedule/index.jsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { getFormatName } from '@wca/helpers'
+import _ from 'lodash'
 import moment from 'moment'
 import React, { useContext, useMemo } from 'react'
 import {
@@ -153,9 +154,7 @@ function VenueSchedule({ schedule, venue, events }) {
 }
 
 function OneDayTable({ activities, venue, rounds }) {
-  const sortedActivities = activities.sort(
-    (a, b) => new Date(a.startTime) > new Date(b.startTime)
-  )
+  const sortedActivities = _.sortBy(activities, (a) => a.startTime)
 
   return (
     <Table striped>

--- a/Frontend/src/pages/schedule/index.jsx
+++ b/Frontend/src/pages/schedule/index.jsx
@@ -64,12 +64,8 @@ export default function Schedule() {
   const venueCount = wcif?.schedule?.venues?.length
 
   const panes = useMemo(
-    () => [
-      // {
-      //   menuItem: 'All Venues',
-      //   render: () => <>Combined view in local timezone??</>,
-      // },
-      ...(wcif?.schedule?.venues ?? []).map((venue) => ({
+    () =>
+      wcif?.schedule?.venues?.map((venue) => ({
         menuItem: venue.name,
         render: () => (
           <VenueSchedule
@@ -78,8 +74,7 @@ export default function Schedule() {
             events={wcif.events}
           />
         ),
-      })),
-    ],
+      })) ?? [],
     [wcif?.schedule]
   )
 
@@ -202,7 +197,7 @@ function HeaderRow() {
 }
 
 function ActivityRow({ activity, venue, round, room }) {
-  // note: round/room may be undefined for custom activities like lunch
+  // note: round may be undefined for custom activities like lunch
 
   const { name, startTime, endTime } = activity
   const timeZone = venue.timezone

--- a/Frontend/src/pages/schedule/index.jsx
+++ b/Frontend/src/pages/schedule/index.jsx
@@ -1,6 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
 import { getFormatName } from '@wca/helpers'
-import _ from 'lodash'
 import moment from 'moment'
 import React, { useContext, useMemo } from 'react'
 import {
@@ -154,7 +153,7 @@ function VenueSchedule({ schedule, venue, events }) {
 }
 
 function OneDayTable({ activities, venue, rounds }) {
-  const sortedActivities = _.sortBy(activities, (a) => a.startTime)
+  const sortedActivities = [...activities].sort(compareActivities)
 
   return (
     <Table striped>
@@ -230,4 +229,21 @@ function ActivityRow({ activity, venue, round, room }) {
       </TableCell>
     </Table.Row>
   )
+}
+
+const compareActivities = (a, b) => {
+  // sort by start time, with longer activities first for ties
+  if (a.startTime < b.startTime) {
+    return -1
+  }
+  if (a.startTime > b.startTime) {
+    return 1
+  }
+  if (a.endTime < b.endTime) {
+    return 1
+  }
+  if (a.endTime > b.endTime) {
+    return -1
+  }
+  return 0
 }

--- a/Frontend/src/pages/schedule/index.jsx
+++ b/Frontend/src/pages/schedule/index.jsx
@@ -54,13 +54,16 @@ export default function Schedule() {
           ),
           date
         )
+        const rounds = wcif.events.flatMap((events) => events.rounds)
+        const rooms = wcif.schedule.venues.flatMap((venue) => venue.rooms)
 
         return (
           <ScheduleOnDate
             key={date.getDate()}
             date={date}
             activities={activitiesForDay}
-            wcif={wcif}
+            rounds={rounds}
+            rooms={rooms}
           />
         )
       })}
@@ -68,7 +71,7 @@ export default function Schedule() {
   )
 }
 
-function ScheduleOnDate({ date, activities, wcif }) {
+function ScheduleOnDate({ date, activities, rounds, rooms }) {
   const sortedActivities = activities.sort(
     (a, b) => new Date(a.startTime) > new Date(b.startTime)
   )
@@ -80,16 +83,14 @@ function ScheduleOnDate({ date, activities, wcif }) {
         <ScheduleHeaderRow />
         <Table.Body>
           {sortedActivities.map((activity) => {
-            const round = wcif.events
-              .flatMap((events) => events.rounds)
-              .find((round) => round.id === activity.activityCode)
-            const room = wcif.schedule.venues
-              .flatMap((venue) => venue.rooms)
-              .find((room) =>
-                room.activities.some(
-                  (ac) => ac.activityCode === activity.activityCode
-                )
+            const round = rounds.find(
+              (round) => round.id === activity.activityCode
+            )
+            const room = rooms.find((room) =>
+              room.activities.some(
+                (ac) => ac.activityCode === activity.activityCode
               )
+            )
 
             return (
               <ScheduleActivityRow
@@ -124,6 +125,8 @@ function ScheduleHeaderRow() {
 }
 
 function ScheduleActivityRow({ activity, round, room }) {
+  // note: round/room may be undefined for custom activities like lunch
+
   const { name, startTime, endTime } = activity
 
   return (

--- a/Frontend/src/pages/schedule/index.jsx
+++ b/Frontend/src/pages/schedule/index.jsx
@@ -23,9 +23,11 @@ const getDatesStartingOn = (startDate, numberOfDays) => {
   return range
 }
 
-const activitiesByDate = (activities, date) => {
+const activitiesByDate = (activities, date, timeZone) => {
   return activities.filter(
-    (activity) => new Date(activity.startTime).getDate() === date.getDate()
+    (activity) =>
+      new Date(activity.startTime).toLocaleDateString([], { timeZone }) ===
+      date.toLocaleDateString([], { timeZone: 'UTC' })
   )
 }
 
@@ -107,6 +109,7 @@ export default function Schedule() {
 function VenueSchedule({ schedule, venue, events }) {
   const venueCount = schedule.venues.length
   const mapLink = `https://www.google.com/maps/place/${venue.latitudeMicrodegrees},${venue.longitudeMicrodegrees}`
+  const timeZone = venue.timezone
 
   return (
     <>
@@ -119,7 +122,7 @@ function VenueSchedule({ schedule, venue, events }) {
           {venueCount === 1
             ? ', the sole venue for this competition.'
             : `, one of ${venueCount} venues for this competition.`}{' '}
-          This schedule is displayed in the venue's time zone: {venue.timezone}.
+          This schedule is displayed in the venue's time zone: {timeZone}.
         </Message.Content>
       </Message>
 
@@ -128,15 +131,15 @@ function VenueSchedule({ schedule, venue, events }) {
           const title = `Schedule for ${getLongDate(date)}`
           const activitiesForDay = activitiesByDate(
             venue.rooms.flatMap((room) => room.activities),
-            date
+            date,
+            timeZone
           )
           const rounds = events.flatMap((events) => events.rounds)
 
           return (
-            <Segment basic>
+            <Segment key={date.getDate()} basic>
               <Header as="h2">{title}</Header>
               <OneDayTable
-                key={date.getDate()}
                 activities={activitiesForDay}
                 rounds={rounds}
                 venue={venue}


### PR DESCRIPTION
Before, there was a single schedule displaying all venues, with activities showing in the user's local timezone. And the activities were not sorted properly.

Now there is a tab per venue, times are in that venue's timezone, and activities are sorted. A message to this effect is at the top, and tabs are omitted if there's only 1 venue.

The local mock data doesn't have enough edges cases, so I'd like to deploy this to staging and have some things checked:

- [ ] Multiple-day competitions show the activities on the correct day with the correct time.
- [ ] Multi-venue competitions show the activities in the correct venue tab.
- [ ] Viewing a competition in a different time zone displays the activities on the correct days, in the venue's time zone.

There are several more schedule things to do (when compared to the existing monolith schedule page), but hopefully this PR will get merged soon and I can do them in separate PRs:

- [ ] Ability to toggle rooms on/off within a venue.
- [ ] Ability to toggle events on/off within a venue.
- [ ] The calendar view.
- [ ] Time limit, cutoff, etc. definitions.

I hate dealing with time and time zones.