### PR TITLE
Save schedule view via new useStoredState hook

### DIFF
--- a/Frontend/src/hooks/useStoredState.js
+++ b/Frontend/src/hooks/useStoredState.js
@@ -1,0 +1,29 @@
+import { useState } from 'react'
+
+/*
+ * Only works for strings as-is, but can use JSON.parse and JSON.stringify
+ * to generalize it.
+ */
+
+/**
+ * This functions like the useState hook, but it fetches the state stored in
+ * local storage, via the given key, on subsequent uses.
+ */
+export function useStoredState(initialState, key) {
+  const storedState = localStorage.getItem(key)
+
+  const [state, setState] = useState(() => {
+    if (storedState === null) {
+      localStorage.setItem(key, initialState)
+      return initialState
+    }
+    return storedState
+  })
+
+  function setAndStoreState(newState) {
+    setState(newState)
+    localStorage.setItem(key, newState)
+  }
+
+  return [state, setAndStoreState]
+}

--- a/Frontend/src/hooks/useStoredState.js
+++ b/Frontend/src/hooks/useStoredState.js
@@ -1,13 +1,14 @@
 import { useState } from 'react'
 
-/*
- * Only works for strings as-is, but can use JSON.parse and JSON.stringify
- * to generalize it.
- */
-
 /**
  * This functions like the useState hook, but it fetches the state stored in
  * local storage, via the given key, on subsequent uses.
+ *
+ * Do NOT call this twice with the same key - updating one of such a pair
+ * will not update the other's state.
+ *
+ * Currently only works for strings, but can be generalized with JSON.parse
+ * and JSON.stringify if needed.
  */
 export function useStoredState(initialState, key) {
   const storedState = localStorage.getItem(key)

--- a/Frontend/src/pages/schedule/Schedule.jsx
+++ b/Frontend/src/pages/schedule/Schedule.jsx
@@ -1,5 +1,6 @@
 import React, { useReducer, useState } from 'react'
 import { Message, Segment } from 'semantic-ui-react'
+import { useStoredState } from '../../hooks/useStoredState'
 import { getDatesStartingOn } from '../../lib/dates'
 import CalendarView from './CalendarView'
 import EventsSelector from './EventsSelector'
@@ -144,8 +145,7 @@ export default function Schedule({ wcif }) {
 
   // view
 
-  // TODO: save in local storage via a new `useSavedState` hook
-  const [activeView, setActiveView] = useState('calendar')
+  const [activeView, setActiveView] = useStoredState('calendar', 'scheduleView')
 
   // TODO: if time zones are changeable, these may be wrong
   const activeDates = getDatesStartingOn(


### PR DESCRIPTION
A global calendar vs table state, independent of which competition is being viewed.

Saved in the browser local storage, so even if a new user logs in on the same browser, the previous view will be kept. Which seems fine to me.