### PR TITLE
Reenable Esbuild Live Reloading

### DIFF
--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="/dist/bundle.css">
     <script>
         // For Live Reload
-        new EventSource('/esbuild').addEventListener('change', () => location.reload())
+        new EventSource('http://localhost:3000/esbuild').addEventListener('change', () => location.reload())
     </script>
 </head>
 <body>

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -111,6 +111,8 @@ services:
     container_name: frontend
     build:
       context: Frontend
+    ports:
+      - "3000:3000"
     tty:
       true
     command: bash -c "npm run watch"


### PR DESCRIPTION
When I introduced the nginx it seems to have broken live reloading, this fixes it by making the event watcher not go through the nginx.