### PR TITLE
Schedule event selector

### DIFF
--- a/Frontend/src/lib/activities.js
+++ b/Frontend/src/lib/activities.js
@@ -30,10 +30,14 @@ export const groupActivities = (activities) => {
   return grouped
 }
 
-export const areGroupable = (act1, act2) => {
+const areGroupable = (act1, act2) => {
   return (
     act1.startTime === act2.startTime &&
     act1.endTime === act2.endTime &&
     act1.activityCode === act2.activityCode
   )
+}
+
+export const getActivityEvent = (activity) => {
+  return activity.activityCode.split('-')[0]
 }

--- a/Frontend/src/lib/activities.js
+++ b/Frontend/src/lib/activities.js
@@ -41,3 +41,7 @@ const areGroupable = (act1, act2) => {
 export const getActivityEvent = (activity) => {
   return activity.activityCode.split('-')[0]
 }
+
+export const getActivityRoundId = (activity) => {
+  return activity.activityCode.split('-').slice(0, 2).join('-')
+}

--- a/Frontend/src/lib/activities.ts
+++ b/Frontend/src/lib/activities.ts
@@ -1,4 +1,6 @@
-export const earliestWithLongestTieBreaker = (a, b) => {
+import { Activity } from '@wca/helpers'
+
+export const earliestWithLongestTieBreaker = (a: Activity, b: Activity) => {
   if (a.startTime < b.startTime) {
     return -1
   }
@@ -15,8 +17,8 @@ export const earliestWithLongestTieBreaker = (a, b) => {
 }
 
 // assumes they are sorted
-export const groupActivities = (activities) => {
-  const grouped = []
+export const groupActivities = (activities: Activity[]) => {
+  const grouped: Activity[][] = []
   activities.forEach((activity) => {
     if (
       grouped.length > 0 &&
@@ -30,18 +32,18 @@ export const groupActivities = (activities) => {
   return grouped
 }
 
-const areGroupable = (act1, act2) => {
+const areGroupable = (a: Activity, b: Activity) => {
   return (
-    act1.startTime === act2.startTime &&
-    act1.endTime === act2.endTime &&
-    act1.activityCode === act2.activityCode
+    a.startTime === b.startTime &&
+    a.endTime === b.endTime &&
+    a.activityCode === b.activityCode
   )
 }
 
-export const getActivityEvent = (activity) => {
+export const getActivityEvent = (activity: Activity) => {
   return activity.activityCode.split('-')[0]
 }
 
-export const getActivityRoundId = (activity) => {
+export const getActivityRoundId = (activity: Activity) => {
   return activity.activityCode.split('-').slice(0, 2).join('-')
 }

--- a/Frontend/src/pages/schedule/EventsSelector.jsx
+++ b/Frontend/src/pages/schedule/EventsSelector.jsx
@@ -1,7 +1,0 @@
-import React from 'react'
-
-// TODO
-
-export default function EventsSelector() {
-  return <p>Events selector does not exist yet. All events are selected.</p>
-}

--- a/Frontend/src/pages/schedule/Schedule.jsx
+++ b/Frontend/src/pages/schedule/Schedule.jsx
@@ -130,6 +130,7 @@ export default function Schedule({ wcif }) {
     activeIdReducer,
     events.map((event) => event.id)
   )
+  const activeEvents = events.filter(({ id }) => activeEventIds.includes(id))
 
   // time zones
 
@@ -207,14 +208,14 @@ export default function Schedule({ wcif }) {
           dates={activeDates}
           timeZone={activeTimeZone}
           venuesShown={activeVenues}
-          events={wcif.events}
+          activeEvents={activeEvents}
         />
       ) : (
         <TableView
           dates={activeDates}
           timeZone={activeTimeZone}
           rooms={activeRooms}
-          events={wcif.events}
+          activeEvents={activeEvents}
         />
       )}
     </Segment>

--- a/Frontend/src/pages/schedule/Schedule.jsx
+++ b/Frontend/src/pages/schedule/Schedule.jsx
@@ -1,10 +1,10 @@
+import { EventSelector } from '@thewca/wca-components'
 import React, { useReducer, useState } from 'react'
 import { Message, Segment } from 'semantic-ui-react'
 import { useStoredState } from '../../hooks/useStoredState'
 import { earliestWithLongestTieBreaker } from '../../lib/activities'
 import { getDatesBetweenInclusive } from '../../lib/dates'
 import CalendarView from './CalendarView'
-import EventsSelector from './EventsSelector'
 import TableView from './TableView'
 import TimeZoneSelector from './TimeZone'
 import VenuesAndRooms from './VenuesAndRooms'
@@ -184,11 +184,14 @@ export default function Schedule({ wcif }) {
         dispatchRooms={dispatchRooms}
       />
 
-      <EventsSelector
-        events={events}
-        activeEventIds={activeEventIds}
-        dispatchEvents={dispatchEvents}
-      />
+      <Segment>
+        <EventSelector
+          events={events.map(({ id }) => id)}
+          selected={activeEventIds}
+          handleEventSelection={(ids) => dispatchEvents({ type: 'reset', ids })}
+          size="2x"
+        />
+      </Segment>
 
       <TimeZoneSelector
         venues={venues}

--- a/Frontend/src/pages/schedule/TableView.jsx
+++ b/Frontend/src/pages/schedule/TableView.jsx
@@ -4,6 +4,7 @@ import { Checkbox, Header, Segment, Table, TableCell } from 'semantic-ui-react'
 import {
   earliestWithLongestTieBreaker,
   getActivityEvent,
+  getActivityRoundId,
   groupActivities,
 } from '../../lib/activities'
 import { activitiesByDate, getLongDate, getShortTime } from '../../lib/dates'
@@ -79,7 +80,7 @@ function SingleDayTable({
           {groupedActivities.length > 0 ? (
             groupedActivities.map((activityGroup) => {
               const activityRound = rounds.find(
-                (round) => round.id === activityGroup[0].activityCode
+                (round) => round.id === getActivityRoundId(activityGroup[0])
               )
 
               return (
@@ -135,7 +136,7 @@ function ActivityRow({ isExpanded, activityGroup, round, rooms, timeZone }) {
   )
 
   // TODO: create name from activity code when possible (fallback to name property)
-  // TODO: format and time limit not showing up for attempt-based activities (fm, multi)
+  // TODO: time limit not showing up for fm & multi
   // TODO: display times in appropriate format
 
   return (

--- a/Frontend/src/pages/schedule/TableView.jsx
+++ b/Frontend/src/pages/schedule/TableView.jsx
@@ -3,18 +3,24 @@ import React, { useState } from 'react'
 import { Checkbox, Header, Segment, Table, TableCell } from 'semantic-ui-react'
 import {
   earliestWithLongestTieBreaker,
+  getActivityEvent,
   groupActivities,
 } from '../../lib/activities'
 import { activitiesByDate, getLongDate, getShortTime } from '../../lib/dates'
 
-export default function TableView({ dates, timeZone, rooms, events }) {
-  const rounds = events.flatMap((event) => event.rounds)
+export default function TableView({ dates, timeZone, rooms, activeEvents }) {
+  const rounds = activeEvents.flatMap((event) => event.rounds)
 
   const [isExpanded, setIsExpanded] = useState(false)
 
   const sortedActivities = rooms
     .flatMap((room) => room.activities)
     .sort(earliestWithLongestTieBreaker)
+
+  const eventIds = activeEvents.map(({ id }) => id)
+  const visibleActivities = sortedActivities.filter((activity) =>
+    ['other', ...eventIds].includes(getActivityEvent(activity))
+  )
 
   return (
     <>
@@ -28,7 +34,7 @@ export default function TableView({ dates, timeZone, rooms, events }) {
 
       {dates.map((date) => {
         const activitiesForDay = activitiesByDate(
-          sortedActivities,
+          visibleActivities,
           date,
           timeZone
         )


### PR DESCRIPTION
- Add the event selector and filter for selected events.
- Get the correct round info for activities (in particular, fixes multi and fm not having round info).
- Convert activity util file to typescript.

It would be nice to generalize the event selector to allow hiding the non-event activities (those with activity code starting with "other-"). Maybe just a separate toggle would be simpler for now.

Note that the event selector goes off-screen if the screen is too narrow.