### PR TITLE
Shedule selector room colors

### DIFF
--- a/Frontend/src/lib/colors.js
+++ b/Frontend/src/lib/colors.js
@@ -20,9 +20,9 @@ export const hexToRgb = (hexColor) => {
 
   if (match !== null) {
     return [
-      parseInt(match.groups.r, HEX_BASE),
-      parseInt(match.groups.g, HEX_BASE),
-      parseInt(match.groups.b, HEX_BASE),
+      Number.parseInt(match.groups.r, HEX_BASE),
+      Number.parseInt(match.groups.g, HEX_BASE),
+      Number.parseInt(match.groups.b, HEX_BASE),
     ]
   }
 

--- a/Frontend/src/lib/colors.js
+++ b/Frontend/src/lib/colors.js
@@ -1,0 +1,51 @@
+// Note: copy-paste from monolith code's calendar util
+
+const HEX_BASE = 16
+const HEX_CHANNEL_REGEX =
+  /^#(?<r>[0-9A-Fa-f]{2})(?<g>[0-9A-Fa-f]{2})(?<b>[0-9A-Fa-f]{2})$/
+
+/**
+ * Convert a HEX color code to RGB values.
+ *
+ * @example
+ * // returns [255, 255, 255]
+ * getTextColor('#ffffff');
+ *
+ * @param {string} hexColor HEX color code to convert to RGB
+ *
+ * @returns {Array<number>} RBG values, defaults to `[0, 0, 0]` if `hexColor` cannot be parsed
+ */
+export const hexToRgb = (hexColor) => {
+  const match = hexColor.match(HEX_CHANNEL_REGEX)
+
+  if (match !== null) {
+    return [
+      parseInt(match.groups.r, HEX_BASE),
+      parseInt(match.groups.g, HEX_BASE),
+      parseInt(match.groups.b, HEX_BASE),
+    ]
+  }
+
+  return [0, 0, 0]
+}
+
+const WHITE = '#ffffff'
+const BLACK = '#000000'
+
+/**
+ * Compute appropriate text color (black or white) based on how "light" or "dark"
+ * the background color of a calendar item is.
+ *
+ * @example
+ * // returns #000000 (black given white background color)
+ * getTextColor('#ffffff');
+ *
+ * @param {string} backgroundColor Calendar item's background color (in HEX)
+ *
+ * @returns {string} white for "dark" backgrounds, black for "light" backgrounds
+ */
+export const getTextColor = (backgroundColor) => {
+  const [red, green, blue] = hexToRgb(backgroundColor)
+  // formula from https://stackoverflow.com/a/3943023
+  return red * 0.299 + green * 0.587 + blue * 0.114 > 186 ? BLACK : WHITE
+}

--- a/Frontend/src/pages/schedule/VenuesAndRooms.jsx
+++ b/Frontend/src/pages/schedule/VenuesAndRooms.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Form, Grid, Menu, Message } from 'semantic-ui-react'
-import { toDegrees } from '../../lib/venues'
 import { getTextColor } from '../../lib/colors'
+import { toDegrees } from '../../lib/venues'
 
 export default function VenuesAndRooms({
   venues,

--- a/Frontend/src/pages/schedule/VenuesAndRooms.jsx
+++ b/Frontend/src/pages/schedule/VenuesAndRooms.jsx
@@ -31,6 +31,7 @@ export default function VenuesAndRooms({
           secondary
           fluid
           stackable
+          // TODO: can't scroll left when 6+ venues
           widths={Math.min(6, venueCount + 1)}
           style={{ overflowX: 'auto', overflowY: 'hidden' }}
         >
@@ -56,11 +57,13 @@ export default function VenuesAndRooms({
         timeZoneCount={timeZoneCount}
       />
 
-      <RoomSelector
-        rooms={rooms}
-        activeRoomIds={activeRoomIds}
-        toggleRoom={(id) => dispatchRooms({ type: 'toggle', id })}
-      />
+      {rooms.length > 1 && (
+        <RoomSelector
+          rooms={rooms}
+          activeRoomIds={activeRoomIds}
+          toggleRoom={(id) => dispatchRooms({ type: 'toggle', id })}
+        />
+      )}
     </>
   )
 }

--- a/Frontend/src/pages/schedule/VenuesAndRooms.jsx
+++ b/Frontend/src/pages/schedule/VenuesAndRooms.jsx
@@ -67,7 +67,7 @@ export default function VenuesAndRooms({
 
 function RoomSelector({ rooms, activeRoomIds, toggleRoom }) {
   return (
-    <Grid stackable columns={Math.min(5, rooms.length)}>
+    <Grid stackable columns={Math.min(4, rooms.length)}>
       {rooms.map(({ id, name, color }) => (
         <Grid.Column key={id}>
           <div

--- a/Frontend/src/pages/schedule/VenuesAndRooms.jsx
+++ b/Frontend/src/pages/schedule/VenuesAndRooms.jsx
@@ -79,6 +79,7 @@ function RoomSelector({ rooms, activeRoomIds, toggleRoom }) {
               opacity: activeRoomIds.includes(id) ? 1 : 0.5,
               border: 'solid black 1px',
               padding: '1em',
+              height: '100%',
             }}
           >
             <Form.Checkbox

--- a/Frontend/src/pages/schedule/VenuesAndRooms.jsx
+++ b/Frontend/src/pages/schedule/VenuesAndRooms.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Form, Grid, Menu, Message } from 'semantic-ui-react'
 import { toDegrees } from '../../lib/venues'
+import { getTextColor } from '../../lib/colors'
 
 export default function VenuesAndRooms({
   venues,
@@ -67,15 +68,25 @@ export default function VenuesAndRooms({
 function RoomSelector({ rooms, activeRoomIds, toggleRoom }) {
   return (
     <Grid stackable columns={Math.min(5, rooms.length)}>
-      {rooms.map(({ id, name }) => (
-        // TODO: show color
+      {rooms.map(({ id, name, color }) => (
         <Grid.Column key={id}>
-          <Form.Checkbox
-            slider
-            checked={activeRoomIds.includes(id)}
-            label={name}
-            onChange={() => toggleRoom(id)}
-          />
+          <div
+            style={{
+              backgroundColor: color,
+              opacity: activeRoomIds.includes(id) ? 1 : 0.5,
+              border: 'solid black 1px',
+              padding: '1em',
+            }}
+          >
+            <Form.Checkbox
+              slider
+              label={
+                <label style={{ color: getTextColor(color) }}>{name}</label>
+              }
+              checked={activeRoomIds.includes(id)}
+              onChange={() => toggleRoom(id)}
+            />
+          </div>
         </Grid.Column>
       ))}
     </Grid>

--- a/Frontend/src/pages/schedule/VenuesAndRooms.jsx
+++ b/Frontend/src/pages/schedule/VenuesAndRooms.jsx
@@ -79,7 +79,6 @@ function RoomSelector({ rooms, activeRoomIds, toggleRoom }) {
             }}
           >
             <Form.Checkbox
-              slider
               label={
                 <label style={{ color: getTextColor(color) }}>{name}</label>
               }


### PR DESCRIPTION
I copied the util file from the monolith which figures out whether to make the text black or white. Is there a better way to use the same helper function?

![image](https://github.com/thewca/wca-registration/assets/49137025/09e4a3c7-6df4-4cc0-a853-627c633f5e28)

![image](https://github.com/thewca/wca-registration/assets/49137025/6ea2f220-71e9-4e2b-a20e-2884fb0b940f)

Max 4 per row:

![image](https://github.com/thewca/wca-registration/assets/49137025/ac681a2e-34dc-4983-b346-46b01a9beade)

Hidden when the selected venue only has 1 room:

![image](https://github.com/thewca/wca-registration/assets/49137025/d9e5f6f5-f405-4602-afc8-67c767533eca)

Narrow screen:

![image](https://github.com/thewca/wca-registration/assets/49137025/c57d72d9-bb2a-43e7-a389-a85644e8bf0d)

Narrower screen:

![image](https://github.com/thewca/wca-registration/assets/49137025/3a1ebe51-5a01-4d6b-bafa-c7e59a856cb3)
