### PR TITLE
Schedule calendar view

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -23,6 +23,9 @@
   },
   "dependencies": {
     "@dinero.js/currencies": "2.0.0-alpha.14",
+    "@fullcalendar/luxon3": "^6.1.10",
+    "@fullcalendar/react": "^6.1.10",
+    "@fullcalendar/timegrid": "^6.1.10",
     "@stripe/react-stripe-js": "2.4.0",
     "@stripe/stripe-js": "2.4.0",
     "@tanstack/react-query": "4.33.0",

--- a/Frontend/src/lib/activities.ts
+++ b/Frontend/src/lib/activities.ts
@@ -1,11 +1,11 @@
 import { Activity } from '@wca/helpers'
+import { DateTime } from 'luxon'
 import {
+  addEndBufferWithinDay,
   doesRangeCrossMidnight,
   roundBackToHour,
-  addEndBufferWithinDay,
   todayWithTime,
 } from './dates'
-import { DateTime } from 'luxon'
 
 export const earliestWithLongestTieBreaker = (a: Activity, b: Activity) => {
   if (a.startTime < b.startTime) {
@@ -100,7 +100,6 @@ export const latestTimeOfDayWithBuffer = (
 
   if (result === '00:00:00') {
     return '24:00:00'
-  } else {
-    return result
   }
+  return result
 }

--- a/Frontend/src/lib/activities.ts
+++ b/Frontend/src/lib/activities.ts
@@ -1,4 +1,11 @@
 import { Activity } from '@wca/helpers'
+import {
+  doesRangeCrossMidnight,
+  roundBackToHour,
+  addEndBufferWithinDay,
+  todayWithTime,
+} from './dates'
+import { DateTime } from 'luxon'
 
 export const earliestWithLongestTieBreaker = (a: Activity, b: Activity) => {
   if (a.startTime < b.startTime) {
@@ -46,4 +53,54 @@ export const getActivityEvent = (activity: Activity) => {
 
 export const getActivityRoundId = (activity: Activity) => {
   return activity.activityCode.split('-').slice(0, 2).join('-')
+}
+
+export const earliestTimeOfDayWithBuffer = (
+  activities: Activity[],
+  timeZone: string
+) => {
+  if (activities.length === 0) return undefined
+
+  const doesAnyCrossMidnight = activities.some(({ startTime, endTime }) =>
+    doesRangeCrossMidnight(startTime, endTime, timeZone)
+  )
+  if (doesAnyCrossMidnight) {
+    return '00:00:00'
+  }
+
+  const startTimes = activities.map(({ startTime }) =>
+    todayWithTime(startTime, timeZone)
+  )
+  return roundBackToHour(DateTime.min(...startTimes)).toISOTime({
+    suppressMilliseconds: true,
+    includeOffset: false,
+  })
+}
+
+export const latestTimeOfDayWithBuffer = (
+  activities: Activity[],
+  timeZone: string
+) => {
+  if (activities.length === 0) return undefined
+
+  const doesAnyCrossMidnight = activities.some(({ startTime, endTime }) =>
+    doesRangeCrossMidnight(startTime, endTime, timeZone)
+  )
+  if (doesAnyCrossMidnight) {
+    return '24:00:00'
+  }
+
+  const endTimes = activities.map(({ endTime }) =>
+    todayWithTime(endTime, timeZone)
+  )
+  const result = addEndBufferWithinDay(DateTime.max(...endTimes)).toISOTime({
+    suppressMilliseconds: true,
+    includeOffset: false,
+  })
+
+  if (result === '00:00:00') {
+    return '24:00:00'
+  } else {
+    return result
+  }
 }

--- a/Frontend/src/lib/dates.ts
+++ b/Frontend/src/lib/dates.ts
@@ -90,7 +90,6 @@ export const addEndBufferWithinDay = (date: DateTime) => {
   const buffered = date.plus({ minutes: 10 })
   if (buffered.day !== date.day) {
     return date
-  } else {
-    return buffered
   }
+  return buffered
 }

--- a/Frontend/src/lib/dates.ts
+++ b/Frontend/src/lib/dates.ts
@@ -61,3 +61,36 @@ export const getLongDate = (date: string, timeZone: string) => {
     timeZone,
   })
 }
+
+export const doesRangeCrossMidnight = (
+  start: string,
+  end: string,
+  timeZone: string
+) => {
+  const luxonStart = DateTime.fromISO(start).setZone(timeZone)
+  const luxonEnd = DateTime.fromISO(end).setZone(timeZone)
+  return luxonStart.day !== luxonEnd.day
+}
+
+export const todayWithTime = (date: string, timeZone: string) => {
+  const luxonDate = DateTime.fromISO(date).setZone(timeZone)
+  return DateTime.utc().set({
+    hour: luxonDate.hour,
+    minute: luxonDate.minute,
+    second: luxonDate.second,
+    millisecond: luxonDate.millisecond,
+  })
+}
+
+export const roundBackToHour = (date: DateTime) => {
+  return date.set({ minute: 0, second: 0, millisecond: 0 })
+}
+
+export const addEndBufferWithinDay = (date: DateTime) => {
+  const buffered = date.plus({ minutes: 10 })
+  if (buffered.day !== date.day) {
+    return date
+  } else {
+    return buffered
+  }
+}

--- a/Frontend/src/pages/schedule/CalendarView.jsx
+++ b/Frontend/src/pages/schedule/CalendarView.jsx
@@ -11,7 +11,6 @@ import { getTextColor } from '../../lib/colors'
 
 // based on monolith code: https://github.com/thewca/worldcubeassociation.org/blob/0882a86cf5d83c3a0dbc667a59be05ce8845c3e4/WcaOnRails/app/webpacker/components/EditSchedule/EditActivities/index.js
 
-// TODO: calculate bounds from all venue activities, not just active rooms
 // TODO: make column date consistent with table view dates
 // TODO: add tooltip or popup on events for more details
 // TODO: initialDate change doesn't update calendar
@@ -24,6 +23,7 @@ import { getTextColor } from '../../lib/colors'
 export default function CalendarView({
   dates,
   timeZone,
+  activeVenues,
   activeRooms,
   activeEvents,
 }) {
@@ -42,12 +42,15 @@ export default function CalendarView({
       }))
   )
 
-  // ignore which events are (in)active to avoid the calendar height jumping around
-  const activeRoomsActivities = activeRooms.flatMap((room) => room.activities)
+  // independent of which activities are visible,
+  // to prevent calendar height jumping around
+  const activeVenuesActivities = activeVenues.flatMap((venue) =>
+    venue.rooms.flatMap((room) => room.activities)
+  )
   const calendarStart =
-    earliestTimeOfDayWithBuffer(activeRoomsActivities, timeZone) ?? '00:00:00'
+    earliestTimeOfDayWithBuffer(activeVenuesActivities, timeZone) ?? '00:00:00'
   const calendarEnd =
-    latestTimeOfDayWithBuffer(activeRoomsActivities, timeZone) ?? '00:00:00'
+    latestTimeOfDayWithBuffer(activeVenuesActivities, timeZone) ?? '00:00:00'
 
   const onEventClick = () => {
     /* TODO */

--- a/Frontend/src/pages/schedule/CalendarView.jsx
+++ b/Frontend/src/pages/schedule/CalendarView.jsx
@@ -1,8 +1,76 @@
+import FullCalendar from '@fullcalendar/react'
+import timeGridPlugin from '@fullcalendar/timegrid'
+import luxonPlugin from '@fullcalendar/luxon3'
 import React from 'react'
+import { getActivityEvent } from '../../lib/activities'
+import { getTextColor } from '../../lib/colors'
 
-// TODO
+// based on monolith code: https://github.com/thewca/worldcubeassociation.org/blob/0882a86cf5d83c3a0dbc667a59be05ce8845c3e4/WcaOnRails/app/webpacker/components/EditSchedule/EditActivities/index.js
 
-// { dates, timeZone, venuesShown, events }
-export default function CalendarView() {
-  return <p>Calendar view does not exist yet.</p>
+// TODO: start and end times
+// TODO: make column date consistent with table view dates
+// TODO: add tooltip or popup on events for more details
+// TODO: initialDate change doesn't update calendar
+// > can set explicit range, see https://fullcalendar.io/docs/visibleRange
+// TODO: set calendar's locale
+// TODO: table has 24h, calendar has 12h - make consistent (fixed by setting locale?)
+// TODO: indicate that event split across days are such?
+// TODO: add add-to-calendar functionality?
+
+export default function CalendarView({
+  dates,
+  timeZone,
+  activeRooms,
+  activeEvents,
+}) {
+  const eventIds = activeEvents.map(({ id }) => id)
+  const fcActivities = activeRooms.flatMap((room) =>
+    room.activities
+      .filter((activity) =>
+        ['other', ...eventIds].includes(getActivityEvent(activity))
+      )
+      .map((activity) => ({
+        title: activity.name,
+        start: activity.startTime,
+        end: activity.endTime,
+        backgroundColor: room.color,
+        textColor: getTextColor(room.color),
+      }))
+  )
+
+  const onEventClick = () => {
+    /* TODO */
+  }
+
+  return (
+    <FullCalendar
+      // plugins for the basic FullCalendar implementation.
+      //   - timeGridPlugin: Display days as vertical grid
+      //   - luxonPlugin: Support timezones
+      plugins={[timeGridPlugin, luxonPlugin]}
+      // define our "own" view (which is basically just saying how many days we want)
+      initialView="agendaForComp"
+      views={{
+        agendaForComp: {
+          type: 'timeGrid',
+          duration: { days: dates.length },
+        },
+      }}
+      initialDate={dates[0]}
+      // by default, FC offers support for separate "whole-day" events
+      allDaySlot={false} // ? required?
+      // by default, FC would show a "skip to next day" toolbar
+      headerToolbar={false}
+      slotMinTime="00:00:00" // ! adjust
+      slotMaxTime="24:00:00" // ! adjust
+      slotDuration="00:30:00"
+      height="auto"
+      // localization settings
+      // TODO get locale
+      // locale={calendarLocale}
+      timeZone={timeZone}
+      events={fcActivities}
+      eventClick={onEventClick}
+    />
+  )
 }

--- a/Frontend/src/pages/schedule/CalendarView.jsx
+++ b/Frontend/src/pages/schedule/CalendarView.jsx
@@ -13,8 +13,6 @@ import { getTextColor } from '../../lib/colors'
 
 // TODO: make column date consistent with table view dates
 // TODO: add tooltip or popup on events for more details
-// TODO: initialDate change doesn't update calendar
-// > can set explicit range, see https://fullcalendar.io/docs/visibleRange
 // TODO: set calendar's locale
 // TODO: table has 24h, calendar has 12h - make consistent (fixed by setting locale?)
 // TODO: indicate that event split across days are such?
@@ -63,15 +61,16 @@ export default function CalendarView({
         //   - timeGridPlugin: Display days as vertical grid
         //   - luxonPlugin: Support timezones
         plugins={[timeGridPlugin, luxonPlugin]}
-        // define our "own" view (which is basically just saying how many days we want)
+        // define our "own" view
         initialView="agendaForComp"
         views={{
           agendaForComp: {
             type: 'timeGrid',
-            duration: { days: dates.length },
+            // specify start/end rather than duration/initialDate, since
+            // dates may change when changing time zone
+            visibleRange: { start: dates[0], end: dates[dates.length - 1] },
           },
         }}
-        initialDate={dates[0]}
         // by default, FC offers support for separate "whole-day" events
         allDaySlot={false}
         // by default, FC would show a "skip to next day" toolbar

--- a/Frontend/src/pages/schedule/CalendarView.jsx
+++ b/Frontend/src/pages/schedule/CalendarView.jsx
@@ -2,12 +2,16 @@ import FullCalendar from '@fullcalendar/react'
 import timeGridPlugin from '@fullcalendar/timegrid'
 import luxonPlugin from '@fullcalendar/luxon3'
 import React from 'react'
-import { getActivityEvent } from '../../lib/activities'
+import {
+  getActivityEvent,
+  earliestTimeOfDayWithBuffer,
+  latestTimeOfDayWithBuffer,
+} from '../../lib/activities'
 import { getTextColor } from '../../lib/colors'
 
 // based on monolith code: https://github.com/thewca/worldcubeassociation.org/blob/0882a86cf5d83c3a0dbc667a59be05ce8845c3e4/WcaOnRails/app/webpacker/components/EditSchedule/EditActivities/index.js
 
-// TODO: start and end times
+// TODO: calculate bounds from all venue activities, not just active rooms
 // TODO: make column date consistent with table view dates
 // TODO: add tooltip or popup on events for more details
 // TODO: initialDate change doesn't update calendar
@@ -23,11 +27,11 @@ export default function CalendarView({
   activeRooms,
   activeEvents,
 }) {
-  const eventIds = activeEvents.map(({ id }) => id)
+  const activeEventIds = activeEvents.map(({ id }) => id)
   const fcActivities = activeRooms.flatMap((room) =>
     room.activities
       .filter((activity) =>
-        ['other', ...eventIds].includes(getActivityEvent(activity))
+        ['other', ...activeEventIds].includes(getActivityEvent(activity))
       )
       .map((activity) => ({
         title: activity.name,
@@ -38,39 +42,51 @@ export default function CalendarView({
       }))
   )
 
+  // ignore which events are (in)active to avoid the calendar height jumping around
+  const activeRoomsActivities = activeRooms.flatMap((room) => room.activities)
+  const calendarStart =
+    earliestTimeOfDayWithBuffer(activeRoomsActivities, timeZone) ?? '00:00:00'
+  const calendarEnd =
+    latestTimeOfDayWithBuffer(activeRoomsActivities, timeZone) ?? '00:00:00'
+
   const onEventClick = () => {
     /* TODO */
   }
 
   return (
-    <FullCalendar
-      // plugins for the basic FullCalendar implementation.
-      //   - timeGridPlugin: Display days as vertical grid
-      //   - luxonPlugin: Support timezones
-      plugins={[timeGridPlugin, luxonPlugin]}
-      // define our "own" view (which is basically just saying how many days we want)
-      initialView="agendaForComp"
-      views={{
-        agendaForComp: {
-          type: 'timeGrid',
-          duration: { days: dates.length },
-        },
-      }}
-      initialDate={dates[0]}
-      // by default, FC offers support for separate "whole-day" events
-      allDaySlot={false} // ? required?
-      // by default, FC would show a "skip to next day" toolbar
-      headerToolbar={false}
-      slotMinTime="00:00:00" // ! adjust
-      slotMaxTime="24:00:00" // ! adjust
-      slotDuration="00:30:00"
-      height="auto"
-      // localization settings
-      // TODO get locale
-      // locale={calendarLocale}
-      timeZone={timeZone}
-      events={fcActivities}
-      eventClick={onEventClick}
-    />
+    <>
+      <FullCalendar
+        // plugins for the basic FullCalendar implementation.
+        //   - timeGridPlugin: Display days as vertical grid
+        //   - luxonPlugin: Support timezones
+        plugins={[timeGridPlugin, luxonPlugin]}
+        // define our "own" view (which is basically just saying how many days we want)
+        initialView="agendaForComp"
+        views={{
+          agendaForComp: {
+            type: 'timeGrid',
+            duration: { days: dates.length },
+          },
+        }}
+        initialDate={dates[0]}
+        // by default, FC offers support for separate "whole-day" events
+        allDaySlot={false}
+        // by default, FC would show a "skip to next day" toolbar
+        headerToolbar={false}
+        slotMinTime={calendarStart}
+        slotMaxTime={calendarEnd}
+        slotDuration="00:30:00"
+        height="auto"
+        // localization settings
+        // TODO get locale
+        // locale={calendarLocale}
+        timeZone={timeZone}
+        events={fcActivities}
+        eventClick={onEventClick}
+      />
+      {fcActivities.length === 0 && (
+        <em>No activities for the selected rooms/events.</em>
+      )}
+    </>
   )
 }

--- a/Frontend/src/pages/schedule/CalendarView.jsx
+++ b/Frontend/src/pages/schedule/CalendarView.jsx
@@ -1,10 +1,10 @@
+import luxonPlugin from '@fullcalendar/luxon3'
 import FullCalendar from '@fullcalendar/react'
 import timeGridPlugin from '@fullcalendar/timegrid'
-import luxonPlugin from '@fullcalendar/luxon3'
 import React from 'react'
 import {
-  getActivityEvent,
   earliestTimeOfDayWithBuffer,
+  getActivityEvent,
   latestTimeOfDayWithBuffer,
 } from '../../lib/activities'
 import { getTextColor } from '../../lib/colors'

--- a/Frontend/src/pages/schedule/Schedule.jsx
+++ b/Frontend/src/pages/schedule/Schedule.jsx
@@ -215,6 +215,7 @@ export default function Schedule({ wcif }) {
         <CalendarView
           dates={activeDates}
           timeZone={activeTimeZone}
+          activeVenues={activeVenues}
           activeRooms={activeRooms}
           activeEvents={activeEvents}
         />

--- a/Frontend/src/pages/schedule/Schedule.jsx
+++ b/Frontend/src/pages/schedule/Schedule.jsx
@@ -215,14 +215,14 @@ export default function Schedule({ wcif }) {
         <CalendarView
           dates={activeDates}
           timeZone={activeTimeZone}
-          venuesShown={activeVenues}
+          activeRooms={activeRooms}
           activeEvents={activeEvents}
         />
       ) : (
         <TableView
           dates={activeDates}
           timeZone={activeTimeZone}
-          rooms={activeRooms}
+          activeRooms={activeRooms}
           activeEvents={activeEvents}
           activeVenueOrNull={activeVenueOrNull}
         />

--- a/Frontend/src/pages/schedule/TableView.jsx
+++ b/Frontend/src/pages/schedule/TableView.jsx
@@ -15,7 +15,7 @@ import AddToCalendar from './AddToCalendar'
 export default function TableView({
   dates,
   timeZone,
-  rooms,
+  activeRooms,
   activeEvents,
   activeVenueOrNull,
 }) {
@@ -23,7 +23,7 @@ export default function TableView({
 
   const [isExpanded, setIsExpanded] = useState(false)
 
-  const sortedActivities = rooms
+  const sortedActivities = activeRooms
     .flatMap((room) => room.activities)
     .sort(earliestWithLongestTieBreaker)
 
@@ -57,7 +57,7 @@ export default function TableView({
             timeZone={timeZone}
             groupedActivities={groupedActivitiesForDay}
             rounds={rounds}
-            rooms={rooms}
+            rooms={activeRooms}
             isExpanded={isExpanded}
             activeVenueOrNull={activeVenueOrNull}
           />


### PR DESCRIPTION
There are still several things to do; I will do them in (a) follow-up PR(s).

On that note, where do I get the calendar's `locale`?

If an event spans across midnight, then it's displayed twice, once with an end time of midnight and once with a start time on midnight, which seems potentially misleading. This just seems to be the default behaviour and I'm not sure what, if anything, we can/should do about it.

![image](https://github.com/thewca/wca-registration/assets/49137025/b5e6ca10-57eb-4cf5-8a84-4eea74cb68ae)

2-part screenshot:
![image](https://github.com/thewca/wca-registration/assets/49137025/1838a8b0-5e4b-4ba3-992f-632beb37f790)
![image](https://github.com/thewca/wca-registration/assets/49137025/1931ee98-09c8-4748-9c40-c4e76bf6d2cb)

![image](https://github.com/thewca/wca-registration/assets/49137025/dd4116f2-d981-41ca-b009-b01544e34492)

Multiple rooms:

![image](https://github.com/thewca/wca-registration/assets/49137025/50850a70-0f01-4a99-b87e-1112f6471df0)

![image](https://github.com/thewca/wca-registration/assets/49137025/2175d370-d837-4aca-ac0b-c93777f47f7f)

![image](https://github.com/thewca/wca-registration/assets/49137025/5e2b483f-742d-47cf-bfcf-18ecd219d975)

Competition with daylight saving time between 2 days, and also viewed in a different time zone which has the time switch on a different weekend:

![image](https://github.com/thewca/wca-registration/assets/49137025/c920caae-f7a6-4450-bce7-698cae23f383)

![image](https://github.com/thewca/wca-registration/assets/49137025/20056424-72f9-4509-a8ad-26f489d41930)
