### PR TITLE
Refactor dates; remove JS dates; calendar locale

### DIFF
--- a/Frontend/src/lib/activities.ts
+++ b/Frontend/src/lib/activities.ts
@@ -59,28 +59,28 @@ export const getActivityRoundId = (activity: Activity) => {
 export const activitiesOnDate = (
   activities: Activity[],
   date: DateTime,
-  timeZone: string
+  timeZone: string,
 ) => {
   return activities.filter((activity) =>
-    areOnSameDate(DateTime.fromISO(activity.startTime), date, timeZone)
+    areOnSameDate(DateTime.fromISO(activity.startTime), date, timeZone),
   )
 }
 
 export const earliestTimeOfDayWithBuffer = (
   activities: Activity[],
-  timeZone: string
+  timeZone: string,
 ) => {
   if (activities.length === 0) return undefined
 
   const doesAnyCrossMidnight = activities.some(({ startTime, endTime }) =>
-    doesRangeCrossMidnight(startTime, endTime, timeZone)
+    doesRangeCrossMidnight(startTime, endTime, timeZone),
   )
   if (doesAnyCrossMidnight) {
     return '00:00:00'
   }
 
   const startTimes = activities.map(({ startTime }) =>
-    todayWithTime(startTime, timeZone)
+    todayWithTime(startTime, timeZone),
   )
   return roundBackToHour(DateTime.min(...startTimes)).toISOTime({
     suppressMilliseconds: true,
@@ -90,19 +90,19 @@ export const earliestTimeOfDayWithBuffer = (
 
 export const latestTimeOfDayWithBuffer = (
   activities: Activity[],
-  timeZone: string
+  timeZone: string,
 ) => {
   if (activities.length === 0) return undefined
 
   const doesAnyCrossMidnight = activities.some(({ startTime, endTime }) =>
-    doesRangeCrossMidnight(startTime, endTime, timeZone)
+    doesRangeCrossMidnight(startTime, endTime, timeZone),
   )
   if (doesAnyCrossMidnight) {
     return '24:00:00'
   }
 
   const endTimes = activities.map(({ endTime }) =>
-    todayWithTime(endTime, timeZone)
+    todayWithTime(endTime, timeZone),
   )
   const result = addEndBufferWithinDay(DateTime.max(...endTimes)).toISOTime({
     suppressMilliseconds: true,

--- a/Frontend/src/lib/activities.ts
+++ b/Frontend/src/lib/activities.ts
@@ -2,6 +2,7 @@ import { Activity } from '@wca/helpers'
 import { DateTime } from 'luxon'
 import {
   addEndBufferWithinDay,
+  areOnSameDate,
   doesRangeCrossMidnight,
   roundBackToHour,
   todayWithTime,
@@ -55,21 +56,31 @@ export const getActivityRoundId = (activity: Activity) => {
   return activity.activityCode.split('-').slice(0, 2).join('-')
 }
 
+export const activitiesOnDate = (
+  activities: Activity[],
+  date: DateTime,
+  timeZone: string
+) => {
+  return activities.filter((activity) =>
+    areOnSameDate(DateTime.fromISO(activity.startTime), date, timeZone)
+  )
+}
+
 export const earliestTimeOfDayWithBuffer = (
   activities: Activity[],
-  timeZone: string,
+  timeZone: string
 ) => {
   if (activities.length === 0) return undefined
 
   const doesAnyCrossMidnight = activities.some(({ startTime, endTime }) =>
-    doesRangeCrossMidnight(startTime, endTime, timeZone),
+    doesRangeCrossMidnight(startTime, endTime, timeZone)
   )
   if (doesAnyCrossMidnight) {
     return '00:00:00'
   }
 
   const startTimes = activities.map(({ startTime }) =>
-    todayWithTime(startTime, timeZone),
+    todayWithTime(startTime, timeZone)
   )
   return roundBackToHour(DateTime.min(...startTimes)).toISOTime({
     suppressMilliseconds: true,
@@ -79,19 +90,19 @@ export const earliestTimeOfDayWithBuffer = (
 
 export const latestTimeOfDayWithBuffer = (
   activities: Activity[],
-  timeZone: string,
+  timeZone: string
 ) => {
   if (activities.length === 0) return undefined
 
   const doesAnyCrossMidnight = activities.some(({ startTime, endTime }) =>
-    doesRangeCrossMidnight(startTime, endTime, timeZone),
+    doesRangeCrossMidnight(startTime, endTime, timeZone)
   )
   if (doesAnyCrossMidnight) {
     return '24:00:00'
   }
 
   const endTimes = activities.map(({ endTime }) =>
-    todayWithTime(endTime, timeZone),
+    todayWithTime(endTime, timeZone)
   )
   const result = addEndBufferWithinDay(DateTime.max(...endTimes)).toISOTime({
     suppressMilliseconds: true,

--- a/Frontend/src/lib/dates.ts
+++ b/Frontend/src/lib/dates.ts
@@ -49,10 +49,22 @@ export const doesRangeCrossMidnight = (
   return !areOnSameDate(luxonStart, luxonEnd, timeZone)
 }
 
-export const getShortTimeString = (dateTime: string, timeZone = 'local') => {
+export const getSimpleTimeString = (dateTime: string, timeZone = 'local') => {
   return DateTime.fromISO(dateTime)
     .setZone(timeZone)
     .toLocaleString(DateTime.TIME_SIMPLE)
+}
+
+export const getShortTimeString = (dateTime: string, timeZone = 'local') => {
+  return DateTime.fromISO(dateTime)
+    .setZone(timeZone)
+    .toLocaleString(DateTime.TIME_WITH_SHORT_OFFSET)
+}
+
+export const getShortDateString = (dateTime: string, timeZone = 'local') => {
+  return DateTime.fromISO(dateTime)
+    .setZone(timeZone)
+    .toLocaleString(DateTime.DATE_SHORT)
 }
 
 // note: some uses are passing dates with times or dates without times

--- a/Frontend/src/lib/dates.ts
+++ b/Frontend/src/lib/dates.ts
@@ -10,7 +10,7 @@ import { DateTime } from 'luxon'
 export const areOnSameDate = (
   luxonDate1: DateTime,
   luxonDate2: DateTime,
-  timeZone: string
+  timeZone: string,
 ) => {
   return luxonDate1
     .setZone(timeZone)
@@ -42,17 +42,14 @@ export function hasNotPassed(dateTime: string): boolean {
 export const doesRangeCrossMidnight = (
   startDateTime: string,
   endDateTime: string,
-  timeZone: string
+  timeZone: string,
 ) => {
   const luxonStart = DateTime.fromISO(startDateTime)
   const luxonEnd = DateTime.fromISO(endDateTime)
   return !areOnSameDate(luxonStart, luxonEnd, timeZone)
 }
 
-export const getShortTimeString = (
-  dateTime: string,
-  timeZone: string = 'local'
-) => {
+export const getShortTimeString = (dateTime: string, timeZone = 'local') => {
   return DateTime.fromISO(dateTime)
     .setZone(timeZone)
     .toLocaleString(DateTime.TIME_SIMPLE)
@@ -60,28 +57,19 @@ export const getShortTimeString = (
 
 // note: some uses are passing dates with times or dates without times
 // ie: `event_change_deadline_date ?? competitionInfo.start_date`
-export const getMediumDateString = (
-  dateTime: string,
-  timeZone: string = 'local'
-) => {
+export const getMediumDateString = (dateTime: string, timeZone = 'local') => {
   return DateTime.fromISO(dateTime)
     .setZone(timeZone)
     .toLocaleString(DateTime.DATE_MED)
 }
 
-export const getLongDateString = (
-  dateTime: string,
-  timeZone: string = 'local'
-) => {
+export const getLongDateString = (dateTime: string, timeZone = 'local') => {
   return DateTime.fromISO(dateTime)
     .setZone(timeZone)
     .toLocaleString(DateTime.DATE_HUGE)
 }
 
-export const getFullDateTimeString = (
-  dateTime: string,
-  timeZone: string = 'local'
-) => {
+export const getFullDateTimeString = (dateTime: string, timeZone = 'local') => {
   return DateTime.fromISO(dateTime)
     .setZone(timeZone)
     .toLocaleString(DateTime.DATETIME_FULL_WITH_SECONDS)
@@ -91,7 +79,7 @@ export const getFullDateTimeString = (
 export const getDatesBetweenInclusive = (
   startDateTime: string,
   endDateTime: string,
-  timeZone: string
+  timeZone: string,
 ) => {
   // avoid infinite loop on invalid params
   if (startDateTime > endDateTime) return []

--- a/Frontend/src/lib/dates.ts
+++ b/Frontend/src/lib/dates.ts
@@ -1,95 +1,121 @@
-import { Activity } from '@wca/helpers'
 import { DateTime } from 'luxon'
 
-// start/end dates may have different time-of-days
-export const getDatesBetweenInclusive = (
-  startDate: string,
-  endDate: string,
-  timeZone: string,
+// parameter name conventions:
+// - `luxonDate` for luxon DateTime objects
+// - `date` for date-only ISO strings (no time)
+// - `dateTime` for date-and-time ISO strings
+
+//// luxon parameters
+
+export const areOnSameDate = (
+  luxonDate1: DateTime,
+  luxonDate2: DateTime,
+  timeZone: string
 ) => {
-  // avoid infinite loop on invalid params
-  if (startDate > endDate) return []
-
-  const dates: Date[] = []
-  let nextDate = new Date(startDate)
-  while (!areOnSameDate(nextDate, new Date(endDate), timeZone)) {
-    dates.push(nextDate)
-    nextDate = new Date(nextDate)
-    nextDate.setDate(nextDate.getDate() + 1)
-  }
-  dates.push(nextDate)
-  return dates
-}
-
-export const areOnSameDate = (date1: Date, date2: Date, timeZone: string) => {
-  return DateTime.fromJSDate(date1)
+  return luxonDate1
     .setZone(timeZone)
-    .hasSame(DateTime.fromJSDate(date2).setZone(timeZone), 'day')
+    .hasSame(luxonDate2.setZone(timeZone), 'day')
 }
 
-export function isAfterNow(date: string): boolean {
-  return DateTime.fromISO(date) > DateTime.now()
+export const roundBackToHour = (luxonDate: DateTime) => {
+  return luxonDate.set({ minute: 0, second: 0, millisecond: 0 })
 }
 
-export const activitiesByDate = (
-  activities: Activity[],
-  date: Date,
-  timeZone: string,
-) => {
-  return activities.filter((activity) =>
-    areOnSameDate(new Date(activity.startTime), date, timeZone),
-  )
+export const addEndBufferWithinDay = (luxonDate: DateTime) => {
+  const buffered = luxonDate.plus({ minutes: 10 })
+  if (buffered.day !== luxonDate.day) {
+    return luxonDate
+  }
+  return buffered
 }
 
-export const getShortTime = (date: string, timeZone: string) => {
-  return new Date(date).toLocaleTimeString([], {
-    timeStyle: 'short',
-    timeZone,
-  })
+//// string parameters
+
+export function hasPassed(dateTime: string): boolean {
+  return DateTime.fromISO(dateTime) < DateTime.now()
 }
 
-export const getMediumDate = (date: string) => {
-  return DateTime.fromISO(date).toLocaleString(DateTime.DATE_MED)
-}
-
-export const getLongDate = (date: string, timeZone: string) => {
-  return new Date(date).toLocaleDateString([], {
-    weekday: 'long',
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-    timeZone,
-  })
+export function hasNotPassed(dateTime: string): boolean {
+  return DateTime.now() < DateTime.fromISO(dateTime)
 }
 
 export const doesRangeCrossMidnight = (
-  start: string,
-  end: string,
-  timeZone: string,
+  startDateTime: string,
+  endDateTime: string,
+  timeZone: string
 ) => {
-  const luxonStart = DateTime.fromISO(start).setZone(timeZone)
-  const luxonEnd = DateTime.fromISO(end).setZone(timeZone)
-  return luxonStart.day !== luxonEnd.day
+  const luxonStart = DateTime.fromISO(startDateTime)
+  const luxonEnd = DateTime.fromISO(endDateTime)
+  return !areOnSameDate(luxonStart, luxonEnd, timeZone)
 }
 
-export const todayWithTime = (date: string, timeZone: string) => {
-  const luxonDate = DateTime.fromISO(date).setZone(timeZone)
+export const getShortTimeString = (
+  dateTime: string,
+  timeZone: string = 'local'
+) => {
+  return DateTime.fromISO(dateTime)
+    .setZone(timeZone)
+    .toLocaleString(DateTime.TIME_SIMPLE)
+}
+
+// note: some uses are passing dates with times or dates without times
+// ie: `event_change_deadline_date ?? competitionInfo.start_date`
+export const getMediumDateString = (
+  dateTime: string,
+  timeZone: string = 'local'
+) => {
+  return DateTime.fromISO(dateTime)
+    .setZone(timeZone)
+    .toLocaleString(DateTime.DATE_MED)
+}
+
+export const getLongDateString = (
+  dateTime: string,
+  timeZone: string = 'local'
+) => {
+  return DateTime.fromISO(dateTime)
+    .setZone(timeZone)
+    .toLocaleString(DateTime.DATE_HUGE)
+}
+
+export const getFullDateTimeString = (
+  dateTime: string,
+  timeZone: string = 'local'
+) => {
+  return DateTime.fromISO(dateTime)
+    .setZone(timeZone)
+    .toLocaleString(DateTime.DATETIME_FULL_WITH_SECONDS)
+}
+
+// start/end dates may have different time-of-days
+export const getDatesBetweenInclusive = (
+  startDateTime: string,
+  endDateTime: string,
+  timeZone: string
+) => {
+  // avoid infinite loop on invalid params
+  if (startDateTime > endDateTime) return []
+
+  const luxonStart = DateTime.fromISO(startDateTime).setZone(timeZone)
+  const luxonEnd = DateTime.fromISO(endDateTime).setZone(timeZone)
+
+  const datesBetween: DateTime[] = []
+  let nextDate = luxonStart
+  while (!areOnSameDate(nextDate, luxonEnd, timeZone)) {
+    datesBetween.push(nextDate)
+    nextDate = nextDate.plus({ days: 1 })
+  }
+  datesBetween.push(nextDate)
+  return datesBetween
+}
+
+// luxon does not support time-only object, so use today's date in utc
+export const todayWithTime = (dateTime: string, timeZone: string) => {
+  const luxonDate = DateTime.fromISO(dateTime).setZone(timeZone)
   return DateTime.utc().set({
     hour: luxonDate.hour,
     minute: luxonDate.minute,
     second: luxonDate.second,
     millisecond: luxonDate.millisecond,
   })
-}
-
-export const roundBackToHour = (date: DateTime) => {
-  return date.set({ minute: 0, second: 0, millisecond: 0 })
-}
-
-export const addEndBufferWithinDay = (date: DateTime) => {
-  const buffered = date.plus({ minutes: 10 })
-  if (buffered.day !== date.day) {
-    return date
-  }
-  return buffered
 }

--- a/Frontend/src/pages/register/components/CompetingStep.jsx
+++ b/Frontend/src/pages/register/components/CompetingStep.jsx
@@ -20,7 +20,7 @@ import { RegistrationContext } from '../../../api/helper/context/registration_co
 import { UserContext } from '../../../api/helper/context/user_context'
 import { updateRegistration } from '../../../api/registration/patch/update_registration'
 import submitEventRegistration from '../../../api/registration/post/submit_registration'
-import { getMediumDate } from '../../../lib/dates'
+import { getMediumDateString, hasPassed } from '../../../lib/dates'
 import { setMessage } from '../../../ui/events/messages'
 import Processing from './Processing'
 
@@ -36,9 +36,7 @@ export default function CompetingStep({ nextStep }) {
 
   const [comment, setComment] = useState('')
   const [selectedEvents, setSelectedEvents] = useState(
-    preferredEvents.filter((event) =>
-      competitionInfo.event_ids.includes(event),
-    ),
+    preferredEvents.filter((event) => competitionInfo.event_ids.includes(event))
   )
   const [guests, setGuests] = useState(0)
 
@@ -62,14 +60,14 @@ export default function CompetingStep({ nextStep }) {
           errorCode
             ? t(`errors.${errorCode}`)
             : 'Registration update failed with error: ' + data.message,
-          'negative',
+          'negative'
         )
       },
       onSuccess: (data) => {
         setMessage('Registration update succeeded', 'positive')
         queryClient.setQueryData(
           ['registration', competitionInfo.id, user.id],
-          data,
+          data
         )
       },
     })
@@ -83,7 +81,7 @@ export default function CompetingStep({ nextStep }) {
           errorCode
             ? t(`errors.${errorCode}`)
             : 'Registration failed with error: ' + data.message,
-          'negative',
+          'negative'
         )
       },
       onSuccess: (_) => {
@@ -94,10 +92,9 @@ export default function CompetingStep({ nextStep }) {
       },
     })
 
-  const hasRegistrationEditDeadlinePassed =
-    new Date(
-      competitionInfo.event_change_deadline_date ?? competitionInfo.start_date,
-    ) < Date.now()
+  const hasRegistrationEditDeadlinePassed = hasPassed(
+    competitionInfo.event_change_deadline_date ?? competitionInfo.start_date
+  )
   const canUpdateRegistration =
     competitionInfo.allow_registration_edits &&
     !hasRegistrationEditDeadlinePassed
@@ -130,13 +127,13 @@ export default function CompetingStep({ nextStep }) {
           maxEvents === Infinity
             ? 'You must select at least 1 event'
             : `You must select between 1 and ${maxEvents} events`,
-          'negative',
+          'negative'
         )
       } else {
         action()
       }
     },
-    [commentIsValid, eventsAreValid, hasChanges, maxEvents],
+    [commentIsValid, eventsAreValid, hasChanges, maxEvents]
   )
 
   const actionCreateRegistration = () => {
@@ -274,7 +271,7 @@ export default function CompetingStep({ nextStep }) {
               selection
               options={[
                 ...new Array(
-                  (competitionInfo.guests_per_registration_limit ?? 99) + 1, // Arrays start at 0
+                  (competitionInfo.guests_per_registration_limit ?? 99) + 1 // Arrays start at 0
                 ),
               ].map((_, index) => {
                 return {
@@ -297,9 +294,9 @@ export default function CompetingStep({ nextStep }) {
                 position="top center"
                 content={
                   canUpdateRegistration
-                    ? `You can update your registration until ${getMediumDate(
+                    ? `You can update your registration until ${getMediumDateString(
                         competitionInfo.event_change_deadline_date ??
-                          competitionInfo.start_date,
+                          competitionInfo.start_date
                       )}`
                     : 'You can no longer update your registration'
                 }
@@ -312,8 +309,8 @@ export default function CompetingStep({ nextStep }) {
                 {canUpdateRegistration
                   ? 'Update your registration below' // eslint-disable-next-line unicorn/no-nested-ternary
                   : hasRegistrationEditDeadlinePassed
-                    ? 'The deadline to edit your registration has passed'
-                    : 'Registration editing is disabled for this competition'}
+                  ? 'The deadline to edit your registration has passed'
+                  : 'Registration editing is disabled for this competition'}
               </Message.Content>
             </Message>
 

--- a/Frontend/src/pages/register/components/CompetingStep.jsx
+++ b/Frontend/src/pages/register/components/CompetingStep.jsx
@@ -36,7 +36,9 @@ export default function CompetingStep({ nextStep }) {
 
   const [comment, setComment] = useState('')
   const [selectedEvents, setSelectedEvents] = useState(
-    preferredEvents.filter((event) => competitionInfo.event_ids.includes(event))
+    preferredEvents.filter((event) =>
+      competitionInfo.event_ids.includes(event),
+    ),
   )
   const [guests, setGuests] = useState(0)
 
@@ -60,14 +62,14 @@ export default function CompetingStep({ nextStep }) {
           errorCode
             ? t(`errors.${errorCode}`)
             : 'Registration update failed with error: ' + data.message,
-          'negative'
+          'negative',
         )
       },
       onSuccess: (data) => {
         setMessage('Registration update succeeded', 'positive')
         queryClient.setQueryData(
           ['registration', competitionInfo.id, user.id],
-          data
+          data,
         )
       },
     })
@@ -81,7 +83,7 @@ export default function CompetingStep({ nextStep }) {
           errorCode
             ? t(`errors.${errorCode}`)
             : 'Registration failed with error: ' + data.message,
-          'negative'
+          'negative',
         )
       },
       onSuccess: (_) => {
@@ -93,7 +95,7 @@ export default function CompetingStep({ nextStep }) {
     })
 
   const hasRegistrationEditDeadlinePassed = hasPassed(
-    competitionInfo.event_change_deadline_date ?? competitionInfo.start_date
+    competitionInfo.event_change_deadline_date ?? competitionInfo.start_date,
   )
   const canUpdateRegistration =
     competitionInfo.allow_registration_edits &&
@@ -127,13 +129,13 @@ export default function CompetingStep({ nextStep }) {
           maxEvents === Infinity
             ? 'You must select at least 1 event'
             : `You must select between 1 and ${maxEvents} events`,
-          'negative'
+          'negative',
         )
       } else {
         action()
       }
     },
-    [commentIsValid, eventsAreValid, hasChanges, maxEvents]
+    [commentIsValid, eventsAreValid, hasChanges, maxEvents],
   )
 
   const actionCreateRegistration = () => {
@@ -271,7 +273,7 @@ export default function CompetingStep({ nextStep }) {
               selection
               options={[
                 ...new Array(
-                  (competitionInfo.guests_per_registration_limit ?? 99) + 1 // Arrays start at 0
+                  (competitionInfo.guests_per_registration_limit ?? 99) + 1, // Arrays start at 0
                 ),
               ].map((_, index) => {
                 return {
@@ -296,7 +298,7 @@ export default function CompetingStep({ nextStep }) {
                   canUpdateRegistration
                     ? `You can update your registration until ${getMediumDateString(
                         competitionInfo.event_change_deadline_date ??
-                          competitionInfo.start_date
+                          competitionInfo.start_date,
                       )}`
                     : 'You can no longer update your registration'
                 }
@@ -309,8 +311,8 @@ export default function CompetingStep({ nextStep }) {
                 {canUpdateRegistration
                   ? 'Update your registration below' // eslint-disable-next-line unicorn/no-nested-ternary
                   : hasRegistrationEditDeadlinePassed
-                  ? 'The deadline to edit your registration has passed'
-                  : 'Registration editing is disabled for this competition'}
+                    ? 'The deadline to edit your registration has passed'
+                    : 'Registration editing is disabled for this competition'}
               </Message.Content>
             </Message>
 

--- a/Frontend/src/pages/register/index.jsx
+++ b/Frontend/src/pages/register/index.jsx
@@ -12,7 +12,11 @@ import {
 import { CompetitionContext } from '../../api/helper/context/competition_context'
 import { PermissionsContext } from '../../api/helper/context/permission_context'
 import { UserContext } from '../../api/helper/context/user_context'
-import { getLongDate, getMediumDate, isAfterNow } from '../../lib/dates'
+import {
+  getLongDateString,
+  getMediumDateString,
+  hasPassed,
+} from '../../lib/dates'
 import { displayMoneyISO4217 } from '../../lib/money'
 import PermissionMessage from '../../ui/messages/permissionMessage'
 import StepPanel from './components/StepPanel'
@@ -21,9 +25,9 @@ function registrationStatusLabel(competitionInfo) {
   if (competitionInfo['registration_opened?']) {
     return 'OPEN'
   }
-  return isAfterNow(competitionInfo.registration_open)
-    ? 'NOT YET OPEN'
-    : 'CLOSED'
+  return hasPassed(competitionInfo.registration_open)
+    ? 'CLOSED'
+    : 'NOT YET OPEN'
 }
 
 export default function Register() {
@@ -67,7 +71,7 @@ export default function Register() {
                         {competitionInfo.base_entry_fee_lowest_denomination
                           ? displayMoneyISO4217(
                               competitionInfo.base_entry_fee_lowest_denomination,
-                              competitionInfo.currency_code,
+                              competitionInfo.currency_code
                             )
                           : 'No Entry Fee'}
                       </List.Header>
@@ -80,7 +84,7 @@ export default function Register() {
                               {competitionInfo.guests_entry_fee_lowest_denomination
                                 ? displayMoneyISO4217(
                                     competitionInfo.guests_entry_fee_lowest_denomination,
-                                    competitionInfo.currency_code,
+                                    competitionInfo.currency_code
                                   )
                                 : 'Guests attend for free'}
                             </List.Header>
@@ -106,9 +110,11 @@ export default function Register() {
                     <List.Icon name="pencil" />
                     <List.Content>
                       <List.Header>
-                        {getMediumDate(competitionInfo.registration_open)}
+                        {getMediumDateString(competitionInfo.registration_open)}
                         {' until '}
-                        {getMediumDate(competitionInfo.registration_close)}
+                        {getMediumDateString(
+                          competitionInfo.registration_close
+                        )}
                       </List.Header>
                       <List.Description>Registration Period</List.Description>
                       <List.List>
@@ -118,9 +124,9 @@ export default function Register() {
                             <List.Header>
                               {competitionInfo.refund_policy_percent}
                               {'% before '}
-                              {getMediumDate(
+                              {getMediumDateString(
                                 competitionInfo.refund_policy_limit_date ??
-                                  competitionInfo.start_date,
+                                  competitionInfo.start_date
                               )}
                             </List.Header>
                             <List.Description>Refund policy</List.Description>
@@ -130,9 +136,9 @@ export default function Register() {
                           <List.Icon name="save" />
                           <List.Content>
                             <List.Header>
-                              {getMediumDate(
+                              {getMediumDateString(
                                 competitionInfo.event_change_deadline_date ??
-                                  competitionInfo.end_date,
+                                  competitionInfo.end_date
                               )}
                             </List.Header>
                             <List.Description>
@@ -144,9 +150,9 @@ export default function Register() {
                           <List.Icon name="hourglass half" />
                           <List.Content>
                             <List.Header>
-                              {getMediumDate(
+                              {getMediumDateString(
                                 competitionInfo.waiting_list_deadline_date ??
-                                  competitionInfo.start_date,
+                                  competitionInfo.start_date
                               )}
                             </List.Header>
                             <List.Description>
@@ -219,14 +225,14 @@ export default function Register() {
         </div>
       ) : (
         <Message warning>
-          {!isAfterNow(competitionInfo.registration_close)
-            ? `Competition Registration closed on ${getMediumDate(
-                competitionInfo.registration_close,
+          {hasPassed(competitionInfo.registration_close)
+            ? `Competition Registration closed on ${getMediumDateString(
+                competitionInfo.registration_close
               )}`
             : `Competition Registration will open ${DateTime.fromISO(
-                competitionInfo.registration_open,
-              ).toRelativeCalendar()} on ${getLongDate(
-                competitionInfo.registration_open,
+                competitionInfo.registration_open
+              ).toRelativeCalendar()} on ${getLongDateString(
+                competitionInfo.registration_open
               )}, ${
                 !loggedIn ? 'you will need a WCA Account to register' : ''
               }`}

--- a/Frontend/src/pages/register/index.jsx
+++ b/Frontend/src/pages/register/index.jsx
@@ -71,7 +71,7 @@ export default function Register() {
                         {competitionInfo.base_entry_fee_lowest_denomination
                           ? displayMoneyISO4217(
                               competitionInfo.base_entry_fee_lowest_denomination,
-                              competitionInfo.currency_code
+                              competitionInfo.currency_code,
                             )
                           : 'No Entry Fee'}
                       </List.Header>
@@ -84,7 +84,7 @@ export default function Register() {
                               {competitionInfo.guests_entry_fee_lowest_denomination
                                 ? displayMoneyISO4217(
                                     competitionInfo.guests_entry_fee_lowest_denomination,
-                                    competitionInfo.currency_code
+                                    competitionInfo.currency_code,
                                   )
                                 : 'Guests attend for free'}
                             </List.Header>
@@ -113,7 +113,7 @@ export default function Register() {
                         {getMediumDateString(competitionInfo.registration_open)}
                         {' until '}
                         {getMediumDateString(
-                          competitionInfo.registration_close
+                          competitionInfo.registration_close,
                         )}
                       </List.Header>
                       <List.Description>Registration Period</List.Description>
@@ -126,7 +126,7 @@ export default function Register() {
                               {'% before '}
                               {getMediumDateString(
                                 competitionInfo.refund_policy_limit_date ??
-                                  competitionInfo.start_date
+                                  competitionInfo.start_date,
                               )}
                             </List.Header>
                             <List.Description>Refund policy</List.Description>
@@ -138,7 +138,7 @@ export default function Register() {
                             <List.Header>
                               {getMediumDateString(
                                 competitionInfo.event_change_deadline_date ??
-                                  competitionInfo.end_date
+                                  competitionInfo.end_date,
                               )}
                             </List.Header>
                             <List.Description>
@@ -152,7 +152,7 @@ export default function Register() {
                             <List.Header>
                               {getMediumDateString(
                                 competitionInfo.waiting_list_deadline_date ??
-                                  competitionInfo.start_date
+                                  competitionInfo.start_date,
                               )}
                             </List.Header>
                             <List.Description>
@@ -227,12 +227,12 @@ export default function Register() {
         <Message warning>
           {hasPassed(competitionInfo.registration_close)
             ? `Competition Registration closed on ${getMediumDateString(
-                competitionInfo.registration_close
+                competitionInfo.registration_close,
               )}`
             : `Competition Registration will open ${DateTime.fromISO(
-                competitionInfo.registration_open
+                competitionInfo.registration_open,
               ).toRelativeCalendar()} on ${getLongDateString(
-                competitionInfo.registration_open
+                competitionInfo.registration_open,
               )}, ${
                 !loggedIn ? 'you will need a WCA Account to register' : ''
               }`}

--- a/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
+++ b/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
@@ -8,6 +8,7 @@ import { CompetitionContext } from '../../../api/helper/context/competition_cont
 import { PermissionsContext } from '../../../api/helper/context/permission_context'
 import { getAllRegistrations } from '../../../api/registration/get/get_registrations'
 import { useUserData } from '../../../hooks/useUserData'
+import { getFullDateTimeString } from '../../../lib/dates'
 import { addUserData } from '../../../lib/users'
 import { BASE_ROUTE } from '../../../routes'
 import { setMessage } from '../../../ui/events/messages'
@@ -64,7 +65,7 @@ const partitionRegistrations = (registrations) => {
       }
       return result
     },
-    { pending: [], waiting: [], accepted: [], cancelled: [] },
+    { pending: [], waiting: [], accepted: [], cancelled: [] }
   )
 }
 
@@ -107,7 +108,7 @@ export default function RegistrationAdministrationList() {
 
   const [expandedColumns, dispatchColumns] = useReducer(
     columnReducer,
-    initialExpandedColumns,
+    initialExpandedColumns
   )
 
   const {
@@ -128,13 +129,13 @@ export default function RegistrationAdministrationList() {
         errorCode
           ? t(`errors.${errorCode}`)
           : 'Fetching Registrations failed with error: ' + err.message,
-        'negative',
+        'negative'
       )
     },
   })
 
   const { isLoading: infoLoading, data: userInfo } = useUserData(
-    (registrations ?? []).map((r) => r.user_id),
+    (registrations ?? []).map((r) => r.user_id)
   )
 
   const registrationsWithUser = useMemo(() => {
@@ -146,26 +147,26 @@ export default function RegistrationAdministrationList() {
 
   const { waiting, accepted, cancelled, pending } = useMemo(
     () => partitionRegistrations(registrationsWithUser ?? []),
-    [registrationsWithUser],
+    [registrationsWithUser]
   )
 
   const [selected, dispatch] = useReducer(selectedReducer, [])
   const partitionedSelected = useMemo(
     () => ({
       pending: selected.filter((id) =>
-        pending.some((reg) => id === reg.user.id),
+        pending.some((reg) => id === reg.user.id)
       ),
       waiting: selected.filter((id) =>
-        waiting.some((reg) => id === reg.user.id),
+        waiting.some((reg) => id === reg.user.id)
       ),
       accepted: selected.filter((id) =>
-        accepted.some((reg) => id === reg.user.id),
+        accepted.some((reg) => id === reg.user.id)
       ),
       cancelled: selected.filter((id) =>
-        cancelled.some((reg) => id === reg.user.id),
+        cancelled.some((reg) => id === reg.user.id)
       ),
     }),
-    [selected, pending, waiting, accepted, cancelled],
+    [selected, pending, waiting, accepted, cancelled]
   )
 
   const select = (attendees) => dispatch({ type: 'add', attendees })
@@ -183,9 +184,9 @@ export default function RegistrationAdministrationList() {
         (registrationsWithUser ?? []).map((registration) => [
           registration.user.id,
           registration.email,
-        ]),
+        ])
       ),
-    [registrationsWithUser],
+    [registrationsWithUser]
   )
 
   return isRegistrationsLoading || infoLoading ? (
@@ -449,8 +450,8 @@ function TableRow({
 
       <Table.Cell>
         <Popup
-          content={new Date(registered_on).toTimeString()}
-          trigger={<span>{new Date(registered_on).toLocaleDateString()}</span>}
+          content={getFullDateTimeString(registered_on)}
+          trigger={<span>{getFullDateTimeString(registered_on)}</span>}
         />
       </Table.Cell>
 
@@ -460,10 +461,8 @@ function TableRow({
           <Table.Cell>
             {updated_at && (
               <Popup
-                content={new Date(updated_at).toTimeString()}
-                trigger={
-                  <span>{new Date(updated_at).toLocaleDateString()}</span>
-                }
+                content={getFullDateTimeString(updated_at)}
+                trigger={<span>{getFullDateTimeString(updated_at)}</span>}
               />
             )}
           </Table.Cell>

--- a/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
+++ b/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
@@ -8,7 +8,7 @@ import { CompetitionContext } from '../../../api/helper/context/competition_cont
 import { PermissionsContext } from '../../../api/helper/context/permission_context'
 import { getAllRegistrations } from '../../../api/registration/get/get_registrations'
 import { useUserData } from '../../../hooks/useUserData'
-import { getFullDateTimeString } from '../../../lib/dates'
+import { getShortDateString, getShortTimeString } from '../../../lib/dates'
 import { addUserData } from '../../../lib/users'
 import { BASE_ROUTE } from '../../../routes'
 import { setMessage } from '../../../ui/events/messages'
@@ -450,8 +450,8 @@ function TableRow({
 
       <Table.Cell>
         <Popup
-          content={getFullDateTimeString(registered_on)}
-          trigger={<span>{getFullDateTimeString(registered_on)}</span>}
+          content={getShortTimeString(registered_on)}
+          trigger={<span>{getShortDateString(registered_on)}</span>}
         />
       </Table.Cell>
 
@@ -461,8 +461,8 @@ function TableRow({
           <Table.Cell>
             {updated_at && (
               <Popup
-                content={getFullDateTimeString(updated_at)}
-                trigger={<span>{getFullDateTimeString(updated_at)}</span>}
+                content={getShortTimeString(updated_at)}
+                trigger={<span>{getShortDateString(updated_at)}</span>}
               />
             )}
           </Table.Cell>

--- a/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
+++ b/Frontend/src/pages/registration_administration/components/RegistrationAdministrationList.jsx
@@ -65,7 +65,7 @@ const partitionRegistrations = (registrations) => {
       }
       return result
     },
-    { pending: [], waiting: [], accepted: [], cancelled: [] }
+    { pending: [], waiting: [], accepted: [], cancelled: [] },
   )
 }
 
@@ -108,7 +108,7 @@ export default function RegistrationAdministrationList() {
 
   const [expandedColumns, dispatchColumns] = useReducer(
     columnReducer,
-    initialExpandedColumns
+    initialExpandedColumns,
   )
 
   const {
@@ -129,13 +129,13 @@ export default function RegistrationAdministrationList() {
         errorCode
           ? t(`errors.${errorCode}`)
           : 'Fetching Registrations failed with error: ' + err.message,
-        'negative'
+        'negative',
       )
     },
   })
 
   const { isLoading: infoLoading, data: userInfo } = useUserData(
-    (registrations ?? []).map((r) => r.user_id)
+    (registrations ?? []).map((r) => r.user_id),
   )
 
   const registrationsWithUser = useMemo(() => {
@@ -147,26 +147,26 @@ export default function RegistrationAdministrationList() {
 
   const { waiting, accepted, cancelled, pending } = useMemo(
     () => partitionRegistrations(registrationsWithUser ?? []),
-    [registrationsWithUser]
+    [registrationsWithUser],
   )
 
   const [selected, dispatch] = useReducer(selectedReducer, [])
   const partitionedSelected = useMemo(
     () => ({
       pending: selected.filter((id) =>
-        pending.some((reg) => id === reg.user.id)
+        pending.some((reg) => id === reg.user.id),
       ),
       waiting: selected.filter((id) =>
-        waiting.some((reg) => id === reg.user.id)
+        waiting.some((reg) => id === reg.user.id),
       ),
       accepted: selected.filter((id) =>
-        accepted.some((reg) => id === reg.user.id)
+        accepted.some((reg) => id === reg.user.id),
       ),
       cancelled: selected.filter((id) =>
-        cancelled.some((reg) => id === reg.user.id)
+        cancelled.some((reg) => id === reg.user.id),
       ),
     }),
-    [selected, pending, waiting, accepted, cancelled]
+    [selected, pending, waiting, accepted, cancelled],
   )
 
   const select = (attendees) => dispatch({ type: 'add', attendees })
@@ -184,9 +184,9 @@ export default function RegistrationAdministrationList() {
         (registrationsWithUser ?? []).map((registration) => [
           registration.user.id,
           registration.email,
-        ])
+        ]),
       ),
-    [registrationsWithUser]
+    [registrationsWithUser],
   )
 
   return isRegistrationsLoading || infoLoading ? (

--- a/Frontend/src/pages/registration_edit/components/RegistrationEditor.jsx
+++ b/Frontend/src/pages/registration_edit/components/RegistrationEditor.jsx
@@ -18,6 +18,7 @@ import { CompetitionContext } from '../../../api/helper/context/competition_cont
 import { getSingleRegistration } from '../../../api/registration/get/get_registrations'
 import { updateRegistration } from '../../../api/registration/patch/update_registration'
 import { getUserInfo } from '../../../api/user/post/get_user_info'
+import { hasPassed } from '../../../lib/dates'
 import { setMessage } from '../../../ui/events/messages'
 import LoadingMessage from '../../../ui/messages/loadingMessage'
 import styles from './editor.module.scss'
@@ -63,14 +64,14 @@ export default function RegistrationEditor() {
           errorCode
             ? t(`errors.${errorCode}`)
             : 'Registration update failed with error: ' + data.message,
-          'negative',
+          'negative'
         )
       },
       onSuccess: (data) => {
         setMessage('Registration update succeeded', 'positive')
         queryClient.setQueryData(
           ['registration', competitionInfo.id, user_id],
-          data,
+          data
         )
       },
     })
@@ -82,10 +83,10 @@ export default function RegistrationEditor() {
       setStatus(serverRegistration.registration.competing.registration_status)
       setSelectedEvents(serverRegistration.registration.competing.event_ids)
       setAdminComment(
-        serverRegistration.registration.competing.admin_comment ?? '',
+        serverRegistration.registration.competing.admin_comment ?? ''
       )
       setWaitingListPosition(
-        serverRegistration.registration.competing.waiting_list_position ?? 0,
+        serverRegistration.registration.competing.waiting_list_position ?? 0
       )
       setGuests(serverRegistration.registration.guests ?? 0)
     }
@@ -130,7 +131,7 @@ export default function RegistrationEditor() {
         maxEvents === Infinity
           ? 'You must select at least 1 event'
           : `You must select between 1 and ${maxEvents} events`,
-        'negative',
+        'negative'
       )
     } else {
       setMessage('Updating Registration', 'basic')
@@ -162,9 +163,8 @@ export default function RegistrationEditor() {
   ])
 
   const registrationEditDeadlinePassed =
-    DateTime.fromISO(
-      competitionInfo.event_change_deadline_date ?? new Date().toISOString(),
-    ) < DateTime.fromJSDate(new Date())
+    !!competitionInfo.event_change_deadline_date &&
+    hasPassed(competitionInfo.event_change_deadline_date)
 
   return (
     <Segment padded attached>

--- a/Frontend/src/pages/registration_edit/components/RegistrationEditor.jsx
+++ b/Frontend/src/pages/registration_edit/components/RegistrationEditor.jsx
@@ -1,7 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { EventSelector } from '@thewca/wca-components'
 import _ from 'lodash'
-import { DateTime } from 'luxon'
 import React, { useCallback, useContext, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
@@ -64,14 +63,14 @@ export default function RegistrationEditor() {
           errorCode
             ? t(`errors.${errorCode}`)
             : 'Registration update failed with error: ' + data.message,
-          'negative'
+          'negative',
         )
       },
       onSuccess: (data) => {
         setMessage('Registration update succeeded', 'positive')
         queryClient.setQueryData(
           ['registration', competitionInfo.id, user_id],
-          data
+          data,
         )
       },
     })
@@ -83,10 +82,10 @@ export default function RegistrationEditor() {
       setStatus(serverRegistration.registration.competing.registration_status)
       setSelectedEvents(serverRegistration.registration.competing.event_ids)
       setAdminComment(
-        serverRegistration.registration.competing.admin_comment ?? ''
+        serverRegistration.registration.competing.admin_comment ?? '',
       )
       setWaitingListPosition(
-        serverRegistration.registration.competing.waiting_list_position ?? 0
+        serverRegistration.registration.competing.waiting_list_position ?? 0,
       )
       setGuests(serverRegistration.registration.guests ?? 0)
     }
@@ -131,7 +130,7 @@ export default function RegistrationEditor() {
         maxEvents === Infinity
           ? 'You must select at least 1 event'
           : `You must select between 1 and ${maxEvents} events`,
-        'negative'
+        'negative',
       )
     } else {
       setMessage('Updating Registration', 'basic')
@@ -163,7 +162,7 @@ export default function RegistrationEditor() {
   ])
 
   const registrationEditDeadlinePassed =
-    !!competitionInfo.event_change_deadline_date &&
+    Boolean(competitionInfo.event_change_deadline_date) &&
     hasPassed(competitionInfo.event_change_deadline_date)
 
   return (

--- a/Frontend/src/pages/schedule/CalendarView.jsx
+++ b/Frontend/src/pages/schedule/CalendarView.jsx
@@ -13,7 +13,6 @@ import { getTextColor } from '../../lib/colors'
 // based on monolith code: https://github.com/thewca/worldcubeassociation.org/blob/0882a86cf5d83c3a0dbc667a59be05ce8845c3e4/WcaOnRails/app/webpacker/components/EditSchedule/EditActivities/index.js
 
 // TODO: add tooltip or popup on events for more details
-// TODO: set calendar's locale
 // TODO: table has 24h, calendar has 12h - make consistent (fixed by setting locale?)
 // TODO: indicate that event split across days are such?
 // TODO: add add-to-calendar functionality?
@@ -83,9 +82,7 @@ export default function CalendarView({
         slotMaxTime={calendarEnd}
         slotDuration="00:30:00"
         height="auto"
-        // localization settings
-        // TODO get locale
-        // locale={calendarLocale}
+        locale="local"
         timeZone={timeZone}
         events={fcActivities}
         eventClick={onEventClick}

--- a/Frontend/src/pages/schedule/CalendarView.jsx
+++ b/Frontend/src/pages/schedule/CalendarView.jsx
@@ -28,7 +28,7 @@ export default function CalendarView({
   const fcActivities = activeRooms.flatMap((room) =>
     room.activities
       .filter((activity) =>
-        ['other', ...activeEventIds].includes(getActivityEvent(activity))
+        ['other', ...activeEventIds].includes(getActivityEvent(activity)),
       )
       .map((activity) => ({
         title: activity.name,
@@ -36,13 +36,13 @@ export default function CalendarView({
         end: activity.endTime,
         backgroundColor: room.color,
         textColor: getTextColor(room.color),
-      }))
+      })),
   )
 
   // independent of which activities are visible,
   // to prevent calendar height jumping around
   const activeVenuesActivities = activeVenues.flatMap((venue) =>
-    venue.rooms.flatMap((room) => room.activities)
+    venue.rooms.flatMap((room) => room.activities),
   )
   const calendarStart =
     earliestTimeOfDayWithBuffer(activeVenuesActivities, timeZone) ?? '00:00:00'

--- a/Frontend/src/pages/schedule/CalendarView.jsx
+++ b/Frontend/src/pages/schedule/CalendarView.jsx
@@ -1,6 +1,7 @@
 import luxonPlugin from '@fullcalendar/luxon3'
 import FullCalendar from '@fullcalendar/react'
 import timeGridPlugin from '@fullcalendar/timegrid'
+import { DateTime } from 'luxon'
 import React from 'react'
 import {
   earliestTimeOfDayWithBuffer,
@@ -11,7 +12,6 @@ import { getTextColor } from '../../lib/colors'
 
 // based on monolith code: https://github.com/thewca/worldcubeassociation.org/blob/0882a86cf5d83c3a0dbc667a59be05ce8845c3e4/WcaOnRails/app/webpacker/components/EditSchedule/EditActivities/index.js
 
-// TODO: make column date consistent with table view dates
 // TODO: add tooltip or popup on events for more details
 // TODO: set calendar's locale
 // TODO: table has 24h, calendar has 12h - make consistent (fixed by setting locale?)
@@ -29,7 +29,7 @@ export default function CalendarView({
   const fcActivities = activeRooms.flatMap((room) =>
     room.activities
       .filter((activity) =>
-        ['other', ...activeEventIds].includes(getActivityEvent(activity)),
+        ['other', ...activeEventIds].includes(getActivityEvent(activity))
       )
       .map((activity) => ({
         title: activity.name,
@@ -37,13 +37,13 @@ export default function CalendarView({
         end: activity.endTime,
         backgroundColor: room.color,
         textColor: getTextColor(room.color),
-      })),
+      }))
   )
 
   // independent of which activities are visible,
   // to prevent calendar height jumping around
   const activeVenuesActivities = activeVenues.flatMap((venue) =>
-    venue.rooms.flatMap((room) => room.activities),
+    venue.rooms.flatMap((room) => room.activities)
   )
   const calendarStart =
     earliestTimeOfDayWithBuffer(activeVenuesActivities, timeZone) ?? '00:00:00'
@@ -68,13 +68,17 @@ export default function CalendarView({
             type: 'timeGrid',
             // specify start/end rather than duration/initialDate, since
             // dates may change when changing time zone
-            visibleRange: { start: dates[0], end: dates[dates.length - 1] },
+            visibleRange: {
+              start: dates[0].toJSDate(),
+              end: dates[dates.length - 1].toJSDate(),
+            },
           },
         }}
         // by default, FC offers support for separate "whole-day" events
         allDaySlot={false}
         // by default, FC would show a "skip to next day" toolbar
         headerToolbar={false}
+        dayHeaderFormat={DateTime.DATE_HUGE}
         slotMinTime={calendarStart}
         slotMaxTime={calendarEnd}
         slotDuration="00:30:00"

--- a/Frontend/src/pages/schedule/TableView.jsx
+++ b/Frontend/src/pages/schedule/TableView.jsx
@@ -10,7 +10,7 @@ import {
   getActivityRoundId,
   groupActivities,
 } from '../../lib/activities'
-import { getShortTimeString } from '../../lib/dates'
+import { getSimpleTimeString } from '../../lib/dates'
 import { toDegrees } from '../../lib/venues'
 import AddToCalendar from './AddToCalendar'
 
@@ -177,9 +177,9 @@ function ActivityRow({ isExpanded, activityGroup, round, rooms, timeZone }) {
 
   return (
     <Table.Row>
-      <Table.Cell>{getShortTimeString(startTime, timeZone)}</Table.Cell>
+      <Table.Cell>{getSimpleTimeString(startTime, timeZone)}</Table.Cell>
 
-      <Table.Cell>{getShortTimeString(endTime, timeZone)}</Table.Cell>
+      <Table.Cell>{getSimpleTimeString(endTime, timeZone)}</Table.Cell>
 
       <Table.Cell>{name}</Table.Cell>
 

--- a/Frontend/src/pages/schedule/TableView.jsx
+++ b/Frontend/src/pages/schedule/TableView.jsx
@@ -1,14 +1,16 @@
 import { getFormatName } from '@wca/helpers'
+import { DateTime } from 'luxon'
 import React, { useContext, useState } from 'react'
 import { Checkbox, Header, Segment, Table, TableCell } from 'semantic-ui-react'
 import { CompetitionContext } from '../../api/helper/context/competition_context'
 import {
+  activitiesOnDate,
   earliestWithLongestTieBreaker,
   getActivityEvent,
   getActivityRoundId,
   groupActivities,
 } from '../../lib/activities'
-import { activitiesByDate, getLongDate, getShortTime } from '../../lib/dates'
+import { getShortTimeString } from '../../lib/dates'
 import { toDegrees } from '../../lib/venues'
 import AddToCalendar from './AddToCalendar'
 
@@ -29,7 +31,7 @@ export default function TableView({
 
   const eventIds = activeEvents.map(({ id }) => id)
   const visibleActivities = sortedActivities.filter((activity) =>
-    ['other', ...eventIds].includes(getActivityEvent(activity)),
+    ['other', ...eventIds].includes(getActivityEvent(activity))
   )
 
   return (
@@ -43,16 +45,16 @@ export default function TableView({
       />
 
       {dates.map((date) => {
-        const activitiesForDay = activitiesByDate(
+        const activitiesForDay = activitiesOnDate(
           visibleActivities,
           date,
-          timeZone,
+          timeZone
         )
         const groupedActivitiesForDay = groupActivities(activitiesForDay)
 
         return (
           <SingleDayTable
-            key={date.getDate()}
+            key={date.toMillis()}
             date={date}
             timeZone={timeZone}
             groupedActivities={groupedActivitiesForDay}
@@ -78,7 +80,7 @@ function SingleDayTable({
 }) {
   const { competitionInfo } = useContext(CompetitionContext)
 
-  const title = `Schedule for ${getLongDate(date, timeZone)}`
+  const title = `Schedule for ${date.toLocaleString(DateTime.DATE_HUGE)}`
 
   const hasActivities = groupedActivities.length > 0
   const startTime = hasActivities && groupedActivities[0][0].startTime
@@ -87,7 +89,7 @@ function SingleDayTable({
   const activeVenueAddress =
     activeVenueOrNull &&
     `${toDegrees(activeVenueOrNull.latitudeMicrodegrees)},${toDegrees(
-      activeVenueOrNull.longitudeMicrodegrees,
+      activeVenueOrNull.longitudeMicrodegrees
     )}`
 
   return (
@@ -114,7 +116,7 @@ function SingleDayTable({
           {hasActivities ? (
             groupedActivities.map((activityGroup) => {
               const activityRound = rounds.find(
-                (round) => round.id === getActivityRoundId(activityGroup[0]),
+                (round) => round.id === getActivityRoundId(activityGroup[0])
               )
 
               return (
@@ -166,7 +168,7 @@ function ActivityRow({ isExpanded, activityGroup, round, rooms, timeZone }) {
   // note: round may be undefined for custom activities like lunch
   const { format, timeLimit, cutoff, advancementCondition } = round || {}
   const roomsUsed = rooms.filter((room) =>
-    room.activities.some((activity) => activityIds.includes(activity.id)),
+    room.activities.some((activity) => activityIds.includes(activity.id))
   )
 
   // TODO: create name from activity code when possible (fallback to name property)
@@ -175,9 +177,9 @@ function ActivityRow({ isExpanded, activityGroup, round, rooms, timeZone }) {
 
   return (
     <Table.Row>
-      <Table.Cell>{getShortTime(startTime, timeZone)}</Table.Cell>
+      <Table.Cell>{getShortTimeString(startTime, timeZone)}</Table.Cell>
 
-      <Table.Cell>{getShortTime(endTime, timeZone)}</Table.Cell>
+      <Table.Cell>{getShortTimeString(endTime, timeZone)}</Table.Cell>
 
       <Table.Cell>{name}</Table.Cell>
 

--- a/Frontend/src/pages/schedule/TableView.jsx
+++ b/Frontend/src/pages/schedule/TableView.jsx
@@ -31,7 +31,7 @@ export default function TableView({
 
   const eventIds = activeEvents.map(({ id }) => id)
   const visibleActivities = sortedActivities.filter((activity) =>
-    ['other', ...eventIds].includes(getActivityEvent(activity))
+    ['other', ...eventIds].includes(getActivityEvent(activity)),
   )
 
   return (
@@ -48,7 +48,7 @@ export default function TableView({
         const activitiesForDay = activitiesOnDate(
           visibleActivities,
           date,
-          timeZone
+          timeZone,
         )
         const groupedActivitiesForDay = groupActivities(activitiesForDay)
 
@@ -89,7 +89,7 @@ function SingleDayTable({
   const activeVenueAddress =
     activeVenueOrNull &&
     `${toDegrees(activeVenueOrNull.latitudeMicrodegrees)},${toDegrees(
-      activeVenueOrNull.longitudeMicrodegrees
+      activeVenueOrNull.longitudeMicrodegrees,
     )}`
 
   return (
@@ -116,7 +116,7 @@ function SingleDayTable({
           {hasActivities ? (
             groupedActivities.map((activityGroup) => {
               const activityRound = rounds.find(
-                (round) => round.id === getActivityRoundId(activityGroup[0])
+                (round) => round.id === getActivityRoundId(activityGroup[0]),
               )
 
               return (
@@ -168,7 +168,7 @@ function ActivityRow({ isExpanded, activityGroup, round, rooms, timeZone }) {
   // note: round may be undefined for custom activities like lunch
   const { format, timeLimit, cutoff, advancementCondition } = round || {}
   const roomsUsed = rooms.filter((room) =>
-    room.activities.some((activity) => activityIds.includes(activity.id))
+    room.activities.some((activity) => activityIds.includes(activity.id)),
   )
 
   // TODO: create name from activity code when possible (fallback to name property)

--- a/Frontend/src/ui/Competition.jsx
+++ b/Frontend/src/ui/Competition.jsx
@@ -26,7 +26,7 @@ import {
 } from '../api/helper/routes'
 import { getBookmarkedCompetitions } from '../api/user/get/get_bookmarked_competitions'
 import i18n from '../i18n'
-import { getMediumDate } from '../lib/dates'
+import { getMediumDateString } from '../lib/dates'
 import AddToCalendar from '../pages/schedule/AddToCalendar'
 import logo from '../static/wca2020.svg'
 import { setMessage } from './events/messages'
@@ -55,7 +55,7 @@ export default function Competition({ children }) {
   })
 
   const competitionIsBookmarked = (bookmarkedCompetitions ?? []).includes(
-    competitionInfo?.id,
+    competitionInfo?.id
   )
 
   // Hack before we have an image Icon field in the DB
@@ -111,10 +111,10 @@ export default function Competition({ children }) {
                   <List.Icon name="calendar alternate" />
                   <List.Content>
                     {competitionInfo.start_date === competitionInfo.end_date
-                      ? getMediumDate(competitionInfo.start_date)
-                      : `${getMediumDate(
-                          competitionInfo.start_date,
-                        )} to ${getMediumDate(competitionInfo.end_date)}`}
+                      ? getMediumDateString(competitionInfo.start_date)
+                      : `${getMediumDateString(
+                          competitionInfo.start_date
+                        )} to ${getMediumDateString(competitionInfo.end_date)}`}
                   </List.Content>
                 </List.Item>
                 <List.Item>

--- a/Frontend/src/ui/Competition.jsx
+++ b/Frontend/src/ui/Competition.jsx
@@ -55,7 +55,7 @@ export default function Competition({ children }) {
   })
 
   const competitionIsBookmarked = (bookmarkedCompetitions ?? []).includes(
-    competitionInfo?.id
+    competitionInfo?.id,
   )
 
   // Hack before we have an image Icon field in the DB
@@ -113,7 +113,7 @@ export default function Competition({ children }) {
                     {competitionInfo.start_date === competitionInfo.end_date
                       ? getMediumDateString(competitionInfo.start_date)
                       : `${getMediumDateString(
-                          competitionInfo.start_date
+                          competitionInfo.start_date,
                         )} to ${getMediumDateString(competitionInfo.end_date)}`}
                   </List.Content>
                 </List.Item>

--- a/Frontend/src/ui/PageTabs.jsx
+++ b/Frontend/src/ui/PageTabs.jsx
@@ -47,7 +47,7 @@ export default function PageTabs() {
 
   const customTabActive = useMemo(() => {
     return competitionInfo.tabs.some((competitionTab) =>
-      pathMatch(competitionTab.id, location.pathname)
+      pathMatch(competitionTab.id, location.pathname),
     )
   }, [competitionInfo.tabs, location])
 
@@ -69,7 +69,7 @@ export default function PageTabs() {
             navigate(
               `${BASE_ROUTE}/${competitionInfo.id}/${
                 menuConfig.route ?? menuConfig.key
-              }`
+              }`,
             )
           }
           active={pathMatch(menuConfig.key, location.pathname)}
@@ -90,7 +90,7 @@ export default function PageTabs() {
                 key={competitionTab.id}
                 onClick={() =>
                   navigate(
-                    `${BASE_ROUTE}/${competitionInfo.id}/tabs/${competitionTab.id}`
+                    `${BASE_ROUTE}/${competitionInfo.id}/tabs/${competitionTab.id}`,
                   )
                 }
                 active={pathMatch(competitionTab.id, location.pathname)}

--- a/Frontend/src/ui/PageTabs.jsx
+++ b/Frontend/src/ui/PageTabs.jsx
@@ -4,6 +4,7 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { Dropdown, Menu } from 'semantic-ui-react'
 import { CompetitionContext } from '../api/helper/context/competition_context'
 import { PermissionsContext } from '../api/helper/context/permission_context'
+import { hasPassed } from '../lib/dates'
 import { BASE_ROUTE } from '../routes'
 
 export default function PageTabs() {
@@ -23,7 +24,7 @@ export default function PageTabs() {
       optionalTabs.push(registrationsMenuConfig)
       optionalTabs.push(waitingMenuConfig)
     }
-    if (new Date(competitionInfo.registration_open) < Date.now()) {
+    if (hasPassed(competitionInfo.registration_open)) {
       optionalTabs.push(competitorsMenuConfig)
     }
 
@@ -46,7 +47,7 @@ export default function PageTabs() {
 
   const customTabActive = useMemo(() => {
     return competitionInfo.tabs.some((competitionTab) =>
-      pathMatch(competitionTab.id, location.pathname),
+      pathMatch(competitionTab.id, location.pathname)
     )
   }, [competitionInfo.tabs, location])
 
@@ -68,7 +69,7 @@ export default function PageTabs() {
             navigate(
               `${BASE_ROUTE}/${competitionInfo.id}/${
                 menuConfig.route ?? menuConfig.key
-              }`,
+              }`
             )
           }
           active={pathMatch(menuConfig.key, location.pathname)}
@@ -89,7 +90,7 @@ export default function PageTabs() {
                 key={competitionTab.id}
                 onClick={() =>
                   navigate(
-                    `${BASE_ROUTE}/${competitionInfo.id}/tabs/${competitionTab.id}`,
+                    `${BASE_ROUTE}/${competitionInfo.id}/tabs/${competitionTab.id}`
                   )
                 }
                 active={pathMatch(competitionTab.id, location.pathname)}


### PR DESCRIPTION
The end result wasn't as clean as I was hoping, but I think it's a significant improvement.
Besides the refactoring, I also made the calendar view headings match the table headings format (which may look different in your locale):
![image](https://github.com/thewca/wca-registration/assets/49137025/f7e6c405-9724-47c9-a2ed-dd7bf99a7f0e)
![image](https://github.com/thewca/wca-registration/assets/49137025/92b01d99-f494-4915-9bba-9c7c275dd0e7)

~On the other hand, the autoformatting seems to be behaving incorrectly? Not sure what's going on...~
I will fix the lint issues tomorrow.