### PR TITLE
Return empty array before executing query if no hydration data present

### DIFF
--- a/Frontend/src/api/user/post/get_user_info.ts
+++ b/Frontend/src/api/user/post/get_user_info.ts
@@ -15,6 +15,12 @@ export async function getUserInfo(
 export async function getUsersInfo(
   userIds: number[],
 ): Promise<components['schemas']['userInfo'][]> {
+  // safeguard for when there is nothing to query.
+  // Rails blows up with an empty param array so we cannot do this check in the backend.
+  if (userIds.length === 0) {
+    return [];
+  }
+
   const { data, error, response } = await POST('/api/v1/users', {
     body: { ids: userIds },
   })

--- a/Frontend/src/api/user/post/get_user_info.ts
+++ b/Frontend/src/api/user/post/get_user_info.ts
@@ -18,7 +18,7 @@ export async function getUsersInfo(
   // safeguard for when there is nothing to query.
   // Rails blows up with an empty param array so we cannot do this check in the backend.
   if (userIds.length === 0) {
-    return [];
+    return []
   }
 
   const { data, error, response } = await POST('/api/v1/users', {

--- a/Frontend/src/hooks/useUserData.ts
+++ b/Frontend/src/hooks/useUserData.ts
@@ -5,6 +5,10 @@ import { addUserData } from '../lib/users'
 export function useWithUserData<Type extends { user_id: number }>(
   registrations: Type[],
 ) {
+  if (registrations.length === 0) {
+    return { isLoading: false, data: [] }
+  }
+
   // requires a custom comparator because standard JS interprets everything as strings when sorting:
   // https://typescript-eslint.io/rules/require-array-sort-compare/
   const sortedIds = registrations

--- a/Frontend/src/hooks/useUserData.ts
+++ b/Frontend/src/hooks/useUserData.ts
@@ -5,10 +5,6 @@ import { addUserData } from '../lib/users'
 export function useWithUserData<Type extends { user_id: number }>(
   registrations: Type[],
 ) {
-  if (registrations.length === 0) {
-    return { isLoading: false, data: [] }
-  }
-
   // requires a custom comparator because standard JS interprets everything as strings when sorting:
   // https://typescript-eslint.io/rules/require-array-sort-compare/
   const sortedIds = registrations
@@ -23,7 +19,6 @@ export function useWithUserData<Type extends { user_id: number }>(
     staleTime: Infinity,
     refetchOnMount: 'always',
     retry: false,
-    enabled: sortedIds.length > 0, // don't fire an unnecessary request for empty data
     select: (data) => addUserData(registrations, data),
   })
 }


### PR DESCRIPTION
Because there are legitimate use cases for calling this hook with an empty array (most prominently, competitions where nobody has registered / has been accepted yet)