### PR TITLE
Fix two broken messages

### DIFF
--- a/Frontend/src/api/registration/get/get_registrations.ts
+++ b/Frontend/src/api/registration/get/get_registrations.ts
@@ -74,7 +74,7 @@ export async function getAllRegistrations(
 export async function getSingleRegistration(
   userId: number,
   competitionId: string,
-): Promise<RegistrationAdmin> {
+): Promise<RegistrationAdmin | null> {
   const { data, error, response } = await GET('/api/v1/register', {
     params: { query: { competition_id: competitionId, user_id: userId } },
     headers: { Authorization: await getJWT() },
@@ -83,6 +83,10 @@ export async function getSingleRegistration(
     if (error.error === EXPIRED_TOKEN) {
       await getJWT(true)
       return getSingleRegistration(userId, competitionId)
+    }
+    // 404 means that the registration doesn't exist
+    if (response.status === 404) {
+      return null
     }
     throw new BackendError(error.error, response.status)
   }

--- a/Frontend/src/pages/register/components/CompetingStep.jsx
+++ b/Frontend/src/pages/register/components/CompetingStep.jsx
@@ -89,7 +89,6 @@ export default function CompetingStep({ nextStep }) {
       onSuccess: (_) => {
         // We can't update the registration yet, because there might be more steps needed
         // And the Registration might still be processing
-        setMessage('Registration submitted successfully', 'positive')
         setProcessing(true)
       },
     })

--- a/Frontend/src/ui/providers/RegistrationProvider.jsx
+++ b/Frontend/src/ui/providers/RegistrationProvider.jsx
@@ -32,7 +32,7 @@ export default function RegistrationProvider({ children }) {
   return loggedIn && isLoading ? (
     <LoadingMessage />
   ) : // eslint-disable-next-line unicorn/no-nested-ternary
-  isError || !loggedIn ? (
+  isError || !loggedIn || !registration ? (
     <RegistrationContext.Provider
       value={{ registration: null, refetch: () => {}, isRegistered: false }}
     >

--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -107,7 +107,7 @@ class RegistrationController < ApplicationController
     registration = get_single_registration(@user_id, @competition_id)
     render json: registration
   rescue Dynamoid::Errors::RecordNotFound
-    render json: {}, status: :not_found
+    render json: {}
   rescue RegistrationError => e
     render_error(e.http_status, e.error)
   end

--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -107,7 +107,7 @@ class RegistrationController < ApplicationController
     registration = get_single_registration(@user_id, @competition_id)
     render json: registration
   rescue Dynamoid::Errors::RecordNotFound
-    render json: {}
+    render json: {}, status: :not_found
   rescue RegistrationError => e
     render_error(e.http_status, e.error)
   end


### PR DESCRIPTION
- Don't show two messages when registering
- Don't throw an error in the backend when a registration can't be found