### PR TITLE
Add missing :string in worker env_config

### DIFF
--- a/app/worker/env_config.rb
+++ b/app/worker/env_config.rb
@@ -12,7 +12,7 @@ unless defined?(Rails)
       mandatory :AWS_ACCESS_KEY_ID, :string
       mandatory :AWS_SECRET_ACCESS_KEY, :string
       optional :WCA_HOST, :string, ''
-      optional :CODE_ENVIRONMENT, 'development'
+      optional :CODE_ENVIRONMENT, :string, 'development'
     else
       mandatory :QUEUE_URL, :string
       mandatory :WCA_HOST, :string


### PR DESCRIPTION
Missed this in a PR recently and just noticed when trying to rebuild the container 