### PR TITLE
Wrap registration admin action buttons

### DIFF
--- a/Frontend/src/pages/registration_administration/components/actions.module.scss
+++ b/Frontend/src/pages/registration_administration/components/actions.module.scss
@@ -2,5 +2,7 @@
   position: fixed;
   z-index: 1000;
   bottom: 5vh;
-  left: 20vw;
+  left: 20px;
+  right: 20px;
+  flex-wrap: wrap;
 }

--- a/Frontend/src/style/breakpoints.scss
+++ b/Frontend/src/style/breakpoints.scss
@@ -1,0 +1,1 @@
+$semanticMobileBreakpoint: 768px;

--- a/Frontend/src/ui/messages/flash.module.scss
+++ b/Frontend/src/ui/messages/flash.module.scss
@@ -1,6 +1,5 @@
 @import '../../style/font-sizes';
-
-$semanticMobileBreakpoint: 768px;
+@import '../../style/breakpoints';
 
 @media screen and (max-width: $semanticMobileBreakpoint) {
   .message{


### PR DESCRIPTION
Just noticed this while working on the other PR, at first I thought I needed the breakpoints again, but just using flex-wrap fixed it. I still created a breakpoints file if we need it later