### PR TITLE
Limit preregistrations + prevent "preregistration" after reg closes

### DIFF
--- a/app/helpers/competition_api.rb
+++ b/app/helpers/competition_api.rb
@@ -65,6 +65,10 @@ class CompetitionInfo
     Time.now < @competition_json['event_change_deadline_date']
   end
 
+  def registration_not_yet_opened?
+    DateTime.now < @competition_json['registration_open']
+  end
+
   def competitor_limit
     @competition_json['competitor_limit']
   end

--- a/app/services/registration_checker.rb
+++ b/app/services/registration_checker.rb
@@ -55,7 +55,7 @@ class RegistrationChecker
       raise RegistrationError.new(:unauthorized, ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless is_organizer_or_current_user?
 
       # Only organizers can register when registration is closed, and they can only register for themselves - not for other users
-      raise RegistrationError.new(:forbidden, ErrorCodes::REGISTRATION_CLOSED) unless @competition_info.registration_open? || user_can_preregister?
+      raise RegistrationError.new(:forbidden, ErrorCodes::REGISTRATION_CLOSED) unless @competition_info.registration_open? || user_may_preregister?
 
       can_compete = UserApi.can_compete?(@requestee_user_id)
       raise RegistrationError.new(:unauthorized, ErrorCodes::USER_CANNOT_COMPETE) unless can_compete
@@ -70,7 +70,10 @@ class RegistrationChecker
       raise RegistrationError.new(:forbidden, ErrorCodes::ALREADY_REGISTERED_IN_SERIES) if existing_registration_in_series?
     end
 
-    def user_can_preregister?
+    def user_may_preregister?
+      # Can only preregister if registration hasn't closed (ie, if registration is not yet open)
+      return false unless @competition_info.registration_not_yet_opened?
+
       # User must be a listed organizer/delegate to preregister
       return false unless @competition_info.is_organizer_or_delegate?(@requester_user_id)
 

--- a/app/services/registration_checker.rb
+++ b/app/services/registration_checker.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 COMMENT_CHARACTER_LIMIT = 240
+PREREGISTRATIONS_FRACTION_ALLOWED = 0.2
 
 class RegistrationChecker
   def self.create_registration_allowed!(registration_request, competition_info, requesting_user)
@@ -54,7 +55,7 @@ class RegistrationChecker
       raise RegistrationError.new(:unauthorized, ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless is_organizer_or_current_user?
 
       # Only organizers can register when registration is closed, and they can only register for themselves - not for other users
-      raise RegistrationError.new(:forbidden, ErrorCodes::REGISTRATION_CLOSED) unless @competition_info.registration_open? || organizer_modifying_own_registration?
+      raise RegistrationError.new(:forbidden, ErrorCodes::REGISTRATION_CLOSED) unless @competition_info.registration_open? || user_can_preregister?
 
       can_compete = UserApi.can_compete?(@requestee_user_id)
       raise RegistrationError.new(:unauthorized, ErrorCodes::USER_CANNOT_COMPETE) unless can_compete
@@ -69,8 +70,17 @@ class RegistrationChecker
       raise RegistrationError.new(:forbidden, ErrorCodes::ALREADY_REGISTERED_IN_SERIES) if existing_registration_in_series?
     end
 
-    def organizer_modifying_own_registration?
-      @competition_info.is_organizer_or_delegate?(@requester_user_id) && (@requester_user_id == @requestee_user_id)
+    def user_can_preregister?
+      # User must be a listed organizer/delegate to preregister
+      return false unless @competition_info.is_organizer_or_delegate?(@requester_user_id)
+
+      # Organizer/delegate cannot preregister someone else
+      return false unless (@requester_user_id == @requestee_user_id)
+
+      # Can only preregister if preregisration limit is not reached
+      preregistrations_allowed = (@competition_info.competitor_limit*PREREGISTRATIONS_FRACTION_ALLOWED).to_i
+      competitor_count = Registration.where(competition_id: @competition_info.competition_id).count
+      competitor_count < preregistrations_allowed
     end
 
     def is_organizer_or_current_user?

--- a/spec/factories/competition_factory.rb
+++ b/spec/factories/competition_factory.rb
@@ -10,11 +10,12 @@ FactoryBot.define do
     id { 'CubingZANationalChampionship2023' }
     name { 'CubingZA National Championship 2023' }
     event_ids { events }
-    registration_open { '2023-05-05T04:00:00.000Z' }
-    registration_close { '2024-06-14T00:00:00.000Z' }
-    announced_at { '2023-05-01T15:59:53.000Z' }
-    start_date { '2023-06-16' }
-    end_date { '2023-06-18' }
+    registration_open { DateTime.now-2 }
+    registration_close { DateTime.now+10 }
+    announced_at { DateTime.now-3 }
+    event_change_deadline_date { registration_close-1 }
+    start_date { (DateTime.now+15).to_date }
+    end_date { (DateTime.now+16).to_date }
     competitor_limit { 120 }
     cancelled_at { nil }
     url { 'https://www.worldcubeassociation.org/competitions/CubingZANationalChampionship2023' }
@@ -28,7 +29,6 @@ FactoryBot.define do
     country_iso2 { 'ZA' }
     guest_entry_status { 'restricted' }
     guests_per_registration_limit { 2 }
-    event_change_deadline_date { '2024-06-14T00:00:00.000Z' }
     events_per_registration_limit { 'null' }
     using_stripe_payments? { true }
     competition_series_ids { nil }
@@ -51,11 +51,11 @@ FactoryBot.define do
 
     trait :not_open_yet do
       registration_opened? { false }
-      event_change_deadline_date { '2022-06-14T00:00:00.000Z' }
+      registration_open { DateTime.now+1 }
     end
 
     trait :event_change_deadline_passed do
-      event_change_deadline_date { '2022-06-14T00:00:00.000Z' }
+      event_change_deadline_date { DateTime.now-1 }
     end
 
     trait :no_guests do
@@ -64,6 +64,13 @@ FactoryBot.define do
 
     trait :series do
       competition_series_ids { ['CubingZANationalChampionship2023', 'CubingZAWarmup2023'] }
+    end
+    
+    trait :closed do
+      registration_opened? { false }
+      registration_open { DateTime.now-3 }
+      registration_close { DateTime.now-1 }
+      event_change_deadline_date { DateTime.now-1 }
     end
 
     # TODO: Create a flag that returns either the raw JSON (for mocking) or a CompetitionInfo object

--- a/spec/factories/competition_factory.rb
+++ b/spec/factories/competition_factory.rb
@@ -49,7 +49,7 @@ FactoryBot.define do
       guests_per_registration_limit { nil }
     end
 
-    trait :closed do
+    trait :not_open_yet do
       registration_opened? { false }
       event_change_deadline_date { '2022-06-14T00:00:00.000Z' }
     end

--- a/spec/services/registration_checker_spec.rb
+++ b/spec/services/registration_checker_spec.rb
@@ -243,9 +243,17 @@ describe RegistrationChecker do
       end
     end
 
-    # TODO
-    # it 'organizers cant register after registration closes' do
-    # end
+    it 'organizers cant register after registration closes' do
+      registration_request = FactoryBot.build(:registration_request, :organizer)
+      competition_info = CompetitionInfo.new(FactoryBot.build(:competition, :closed))
+
+      expect {
+        RegistrationChecker.create_registration_allowed!(registration_request, competition_info, registration_request['submitted_by'])
+      }.to raise_error(RegistrationError) do |error|
+        expect(error.http_status).to eq(:forbidden)
+        expect(error.error).to eq(ErrorCodes::REGISTRATION_CLOSED)
+      end
+    end
 
     it 'organizers can create registrations for users' do
       registration_request = FactoryBot.build(:registration_request, :organizer_submits)
@@ -950,7 +958,7 @@ describe RegistrationChecker do
 
     it 'user cant cancel registration after registration ends' do
       registration = FactoryBot.create(:registration)
-      competition_info = CompetitionInfo.new(FactoryBot.build(:competition, :not_open_yet))
+      competition_info = CompetitionInfo.new(FactoryBot.build(:competition, :closed))
       update_request = FactoryBot.build(:update_request, user_id: registration[:user_id], competing: { 'status' => 'cancelled' })
 
       expect {


### PR DESCRIPTION
This PR does two things:
* Enforces the WCRP requirement that pre-registrations not be more than 20% of registrations
* Fixes a bug where organizers could register after registration closes (poorly enforced pre-registration check)