### PR TITLE
Only send update emails when competing status is updated

### DIFF
--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -129,8 +129,8 @@ class RegistrationController < ApplicationController
       Registration.increment_competitors_count(@competition_id)
     end
 
-    # Don't send email if we only change the waiting list position
-    if waiting_list_position.blank?
+    # Only send emails when we update the competing status
+    if status.present?
       EmailApi.send_update_email(@competition_id, user_id, status, @current_user)
     end
 


### PR DESCRIPTION
Not sure why I thought that every update got an email (especially because I use status in the method :upside_down_face: )