### PR TITLE
Allow admins to send bulk updates

### DIFF
--- a/app/services/registration_checker.rb
+++ b/app/services/registration_checker.rb
@@ -37,7 +37,7 @@ class RegistrationChecker
 
   def self.bulk_update_allowed!(bulk_update_request, competition_info, requesting_user)
     raise BulkUpdateError.new(:unauthorized, [ErrorCodes::USER_INSUFFICIENT_PERMISSIONS]) unless
-      competition_info.is_organizer_or_delegate?(requesting_user)
+      UserApi.can_administer?(requesting_user, competition_info.id)
 
     errors = {}
     bulk_update_request['requests'].each do |update_request|

--- a/spec/controllers/registration_controller_spec.rb
+++ b/spec/controllers/registration_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe RegistrationController do
-  describe '#create', :tag do
+  describe '#create' do
     before do
       @registration_request = FactoryBot.build(:registration_request)
       stub_request(:get, UserApi.permissions_path(@registration_request['user_id'])).to_return(
@@ -96,9 +96,9 @@ describe RegistrationController do
       @competition = FactoryBot.build(:competition, mock_competition: true)
       stub_request(:get, CompetitionApi.comp_api_url(@competition['id'])).to_return(status: 200, body: @competition.to_json)
 
-      stub_request(:get, UserApi.permissions_path(1306)).to_return(
+      stub_request(:get, UserApi.permissions_path(1400)).to_return(
         status: 200,
-        body: FactoryBot.build(:permissions_response, organized_competitions: [@competition['id']]).to_json,
+        body: FactoryBot.build(:permissions_response, :admin).to_json,
         headers: { content_type: 'application/json' },
       )
     end

--- a/spec/factories/request_factory.rb
+++ b/spec/factories/request_factory.rb
@@ -95,7 +95,7 @@ FactoryBot.define do
       user_ids { [] }
     end
 
-    submitted_by { 1306 }
+    submitted_by { 1400 }
     competition_id { 'CubingZANationalChampionship2023' }
     jwt_token { fetch_jwt_token(submitted_by) }
     requests do

--- a/spec/services/registration_checker_spec.rb
+++ b/spec/services/registration_checker_spec.rb
@@ -1206,9 +1206,15 @@ describe RegistrationChecker do
           body: FactoryBot.build(:permissions_response, organized_competitions: [@competition_info.competition_id]).to_json,
           headers: { content_type: 'application/json' },
         )
+
+        stub_request(:get, UserApi.permissions_path(1400)).to_return(
+          status: 200,
+          body: FactoryBot.build(:permissions_response, :admin).to_json,
+          headers: { content_type: 'application/json' },
+        )
       end
 
-      it 'only organizers can submit bulk updates' do
+      it 'users cant submit bulk updates' do
         failed_update = FactoryBot.build(:update_request, user_id: @registration[:user_id])
         bulk_update_request = FactoryBot.build(:bulk_update_request, requests: [failed_update], submitted_by: @registration[:user_id])
 


### PR DESCRIPTION
I didn't realise that we do a separate check for write-permissions in the bulk update route - this resolves the issue (tested in the UI this time as well!