### PR TITLE
Change `registration_opened?` to `registration_currently_open?` in competition API

### DIFF
--- a/lib/competition_info.rb
+++ b/lib/competition_info.rb
@@ -39,7 +39,7 @@ class CompetitionInfo
   end
 
   def registration_open?
-    @competition_json['registration_opened?']
+    @competition_json['registration_currently_open?']
   end
 
   def using_wca_payment?

--- a/spec/factories/competition_factory.rb
+++ b/spec/factories/competition_factory.rb
@@ -5,7 +5,7 @@ require 'factory_bot_rails'
 FactoryBot.define do
   factory :competition, class: Hash do
     events { ['333', '222', '444', '555', '666', '777', '333bf', '333oh', 'clock', 'minx', 'pyram', 'skewb', 'sq1', '444bf', '555bf', '333mbf'] }
-    registration_opened? { true }
+    registration_currently_open? { true }
     id { 'CubingZANationalChampionship2023' }
     name { 'CubingZA National Championship 2023' }
     event_ids { events }
@@ -49,7 +49,7 @@ FactoryBot.define do
     end
 
     trait :closed do
-      registration_opened? { false }
+      registration_currently_open? { false }
       event_change_deadline_date { '2022-06-14T00:00:00.000Z' }
     end
 

--- a/spec/lib/competition_info_spec.rb
+++ b/spec/lib/competition_info_spec.rb
@@ -21,7 +21,7 @@ describe CompetitionInfo do
 
       it 'false when closed' do
         # Instantiate a CompetitionInfo object with the sample data
-        competition_json = FactoryBot.build(:competition, registration_opened?: false)
+        competition_json = FactoryBot.build(:competition, registration_currently_open?: false)
         competition_info = CompetitionInfo.new(competition_json)
 
         # Call the method being tested


### PR DESCRIPTION
We changed the name of this field in the monolith competition API