### PR TITLE
Qualification fixes from frontend testing

### DIFF
--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -63,7 +63,7 @@ class RegistrationController < ApplicationController
     @user_id = registration_params[:user_id]
     RegistrationChecker.create_registration_allowed!(registration_params, CompetitionApi.find(@competition_id), @current_user)
   rescue RegistrationError => e
-    render_error(e.http_status, e.error)
+    render_error(e.http_status, e.error, e.data)
   end
 
   def update
@@ -81,7 +81,7 @@ class RegistrationController < ApplicationController
 
     RegistrationChecker.update_registration_allowed!(params, CompetitionApi.find!(@competition_id), @current_user)
   rescue RegistrationError => e
-    render_error(e.http_status, e.error)
+    render_error(e.http_status, e.error, e.data)
   end
 
   # You can either view your own registration or one for a competition you administer

--- a/app/services/registration_checker.rb
+++ b/app/services/registration_checker.rb
@@ -217,7 +217,7 @@ class RegistrationChecker
     end
 
     def competitor_qualifies_for_event?(event, qualification)
-      competitor_qualification_results = UserApi.qualifications(@requestee_user_id)
+      competitor_qualification_results = UserApi.qualifications(@requestee_user_id, qualification['whenDate'])
       result_type = qualification['resultType']
 
       competitor_pr = competitor_qualification_results.find { |result| result['eventId'] == event && result['type'] == result_type }

--- a/lib/user_api.rb
+++ b/lib/user_api.rb
@@ -12,8 +12,12 @@ class UserApi < WcaApi
     "#{EnvConfig.WCA_HOST}/api/internal/v1/users/competitor-info"
   end
 
-  def self.competitor_qualifications_path(user_id)
-    "#{EnvConfig.WCA_HOST}/api/v0/results/#{user_id}/qualification_data"
+  def self.competitor_qualifications_path(user_id, date = nil)
+    if date.present?
+      "#{EnvConfig.WCA_HOST}/api/v0/results/#{user_id}/qualification_data?date=#{date}"
+    else
+      "#{EnvConfig.WCA_HOST}/api/v0/results/#{user_id}/qualification_data"
+    end
   end
 
   def self.get_permissions(user_id)
@@ -24,8 +28,8 @@ class UserApi < WcaApi
     HTTParty.post(UserApi.competitor_info_path, headers: { WCA_API_HEADER => self.wca_token }, body: { ids: user_ids.to_a })
   end
 
-  def self.qualifications(user_id)
-    HTTParty.get(UserApi.competitor_qualifications_path(user_id), headers: { WCA_API_HEADER => self.wca_token })
+  def self.qualifications(user_id, date = nil)
+    HTTParty.get(UserApi.competitor_qualifications_path(user_id, date), headers: { WCA_API_HEADER => self.wca_token })
   end
 
   def self.can_compete?(user_id, competition_start_date)

--- a/spec/controllers/registration_controller_spec.rb
+++ b/spec/controllers/registration_controller_spec.rb
@@ -61,7 +61,7 @@ describe RegistrationController do
         sleep 0.1 # Give the queue time to work off the registration - perhaps this should be a queue length query instead?
 
         expect(response.code).to eq('422')
-        expect(response.body).to eq({ error: -4012 }.to_json)
+        expect(response.body).to eq({ error: -4012, data: ['333'] }.to_json)
         expect { Registration.find("#{@competition['id']}-#{@registration_request['user_id']}") }.to raise_error(Dynamoid::Errors::RecordNotFound)
       end
     end

--- a/spec/factories/competition_factory.rb
+++ b/spec/factories/competition_factory.rb
@@ -56,7 +56,7 @@ FactoryBot.define do
           {
             '333' => { 'type' => 'attemptResult', 'resultType' => 'single', 'whenDate' => today, 'level' => 1000 },
             '555' => { 'type' => 'attemptResult', 'resultType' => 'average', 'whenDate' => today, 'level' => 6000 },
-            'pyram' => { 'type' => 'ranking', 'resultType' => 'single', 'whenDate' => today, 'level' => 100 },
+            'pyram' => { 'type' => 'ranking', 'resultType' => 'single', 'whenDate' => (Time.zone.today-2).iso8601, 'level' => 100 },
             'minx' => { 'type' => 'ranking', 'resultType' => 'average', 'whenDate' => today, 'level' => 200 },
             '222' => { 'type' => 'anyResult', 'resultType' => 'single', 'whenDate' => today, 'level' => 0 },
             '555bf' => { 'type' => 'anyResult', 'resultType' => 'average', 'whenDate' => today, 'level' => 0 },
@@ -78,10 +78,10 @@ FactoryBot.define do
           {
             '333' => { 'type' => 'attemptResult', 'resultType' => 'single', 'whenDate' => today, 'level' => 10 },
             '555' => { 'type' => 'attemptResult', 'resultType' => 'average', 'whenDate' => today, 'level' => 60 },
-            'pyram' => { 'type' => 'ranking', 'resultType' => 'single', 'whenDate' => (Time.zone.today-1).iso8601, 'level' => 10 },
-            'minx' => { 'type' => 'ranking', 'resultType' => 'average', 'whenDate' => (Time.zone.today-1).iso8601, 'level' => 20 },
-            '222' => { 'type' => 'anyResult', 'resultType' => 'single', 'whenDate' => (Time.zone.today-1).iso8601, 'level' => 0 },
-            '555bf' => { 'type' => 'anyResult', 'resultType' => 'average', 'whenDate' => (Time.zone.today-1).iso8601, 'level' => 0 },
+            'pyram' => { 'type' => 'ranking', 'resultType' => 'single', 'whenDate' => (Time.zone.today-3).iso8601, 'level' => 10 },
+            'minx' => { 'type' => 'ranking', 'resultType' => 'average', 'whenDate' => (Time.zone.today-3).iso8601, 'level' => 20 },
+            '222' => { 'type' => 'anyResult', 'resultType' => 'single', 'whenDate' => (Time.zone.today-3).iso8601, 'level' => 0 },
+            '555bf' => { 'type' => 'anyResult', 'resultType' => 'average', 'whenDate' => (Time.zone.today-3).iso8601, 'level' => 0 },
           }
         }
       end

--- a/spec/support/qualification_results_faker.rb
+++ b/spec/support/qualification_results_faker.rb
@@ -4,7 +4,7 @@ class QualificationResultsFaker
   attr_accessor :qualification_results
 
   def initialize(
-    date = Time.zone.today.iso8601,
+    date = (Time.zone.today-1).iso8601,
     results_inputs = [
       ['222', 'single', '200'],
       ['333', 'single', '900'],


### PR DESCRIPTION
Fixes 2 issues: 
- RegistrationError `data` parameter not being sent in the response payload [preventing display of the events which the user didn't meet qualification for]
- Not using the `date` parameter of the qualification endpoint meant that trying to register after a qualification date failed, even when you met the qualification