### PR TITLE
Use authenticated route for querying competition API

### DIFF
--- a/lib/competition_api.rb
+++ b/lib/competition_api.rb
@@ -23,7 +23,7 @@ class CompetitionApi < WcaApi
 
   def self.fetch_qualifications(competition_id)
     Rails.cache.fetch("#{competition_id}/qualifications", expires_in: 5.minutes) do
-      response = HTTParty.get("#{url(competition_id)}/qualifications")
+      response = HTTParty.get("#{url(competition_id)}/qualifications", headers: { WCA_API_HEADER => self.wca_token })
       case response.code
       when 200
         @status = 200
@@ -40,7 +40,7 @@ class CompetitionApi < WcaApi
 
   private_class_method def self.fetch_competition(competition_id)
     Rails.cache.fetch(competition_id, expires_in: 5.minutes) do
-      response = HTTParty.get(CompetitionApi.url(competition_id))
+      response = HTTParty.get(CompetitionApi.url(competition_id), headers: { WCA_API_HEADER => self.wca_token })
       case response.code
       when 200
         response.parsed_response

--- a/lib/competition_api.rb
+++ b/lib/competition_api.rb
@@ -13,7 +13,7 @@ class CompetitionApi < WcaApi
   end
 
   def self.url(competition_id)
-    "#{EnvConfig.WCA_HOST}/api/v0/competitions/#{competition_id}"
+    "#{EnvConfig.WCA_HOST}/api/internal/v1/competitions/#{competition_id}"
   end
 
   def self.find!(competition_id)


### PR DESCRIPTION
[Monolith 9809](https://github.com/thewca/worldcubeassociation.org/pull/9809) adds an internal/authenticated route where non-announced competitions can be queried via the API. This PR makes use of that route instead of the un-authenticated one