### PR TITLE
Raise errors on failed API calls

### DIFF
--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -22,7 +22,7 @@ class RegistrationController < ApplicationController
   rescue Dynamoid::Errors::RecordNotFound
     render json: {}, status: :not_found
   rescue RegistrationError => e
-    render_error(e.http_status, e.error)
+    render_error(e.http_status, e.error, e.data)
   end
 
   def count
@@ -223,6 +223,8 @@ class RegistrationController < ApplicationController
     Metrics.registration_dynamodb_errors_counter.increment
     render json: { error: "Error getting registrations #{e}" },
            status: :internal_server_error
+  rescue RegistrationError => e
+    render_error(e.http_status, e.error, e.data)
   end
 
   def import

--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -61,7 +61,7 @@ class RegistrationController < ApplicationController
   def validate_create_request
     @competition_id = registration_params[:competition_id]
     @user_id = registration_params[:user_id]
-    RegistrationChecker.create_registration_allowed!(registration_params, CompetitionApi.find(@competition_id), @current_user)
+    RegistrationChecker.create_registration_allowed!(registration_params, CompetitionApi.find!(@competition_id), @current_user)
   rescue RegistrationError => e
     render_error(e.http_status, e.error, e.data)
   end

--- a/lib/error_codes.rb
+++ b/lib/error_codes.rb
@@ -6,9 +6,10 @@ module ErrorCodes
   EXPIRED_TOKEN = -2
   MISSING_AUTHENTICATION = -3
 
-  # Competition Errors
+  # API Errors
   COMPETITION_NOT_FOUND = -1000
   COMPETITION_API_5XX = -1001
+  MONOLITH_API_ERROR = -1002
 
   # User Errors
   USER_CANNOT_COMPETE = -2001

--- a/lib/user_api.rb
+++ b/lib/user_api.rb
@@ -21,15 +21,15 @@ class UserApi < WcaApi
   end
 
   def self.get_permissions(user_id)
-    HTTParty.get(permissions_path(user_id), headers: { WCA_API_HEADER => self.wca_token })
+    self.get_request(permissions_path(user_id))
   end
 
   def self.get_user_info_pii(user_ids)
-    HTTParty.post(UserApi.competitor_info_path, headers: { WCA_API_HEADER => self.wca_token }, body: { ids: user_ids.to_a })
+    self.post_request(UserApi.competitor_info_path, { ids: user_ids.to_a })
   end
 
   def self.qualifications(user_id, date = nil)
-    HTTParty.get(UserApi.competitor_qualifications_path(user_id, date), headers: { WCA_API_HEADER => self.wca_token })
+    self.get_request(UserApi.competitor_qualifications_path(user_id, date))
   end
 
   def self.can_compete?(user_id, competition_start_date)

--- a/lib/wca_api.rb
+++ b/lib/wca_api.rb
@@ -21,4 +21,24 @@ class WcaApi
       end
     end
   end
+
+  def self.get_request(url)
+    response = HTTParty.get(url, headers: { WCA_API_HEADER => self.wca_token })
+    if response.code == 200
+      response
+    else
+      Metrics.registration_competition_api_error_counter.increment
+      raise RegistrationError.new(:service_unavailable, ErrorCodes::MONOLITH_API_ERROR, { http_code: response.code, body: response.parsed_response })
+    end
+  end
+
+  def self.post_request(url, body)
+    response = HTTParty.post(url, headers: { WCA_API_HEADER => self.wca_token }, body: body)
+    if response.code == 200
+      response
+    else
+      Metrics.registration_competition_api_error_counter.increment
+      raise RegistrationError.new(:service_unavailable, ErrorCodes::MONOLITH_API_ERROR, { http_code: response.code, body: response.parsed_response })
+    end
+  end
 end

--- a/spec/controllers/registration_controller_spec.rb
+++ b/spec/controllers/registration_controller_spec.rb
@@ -272,8 +272,8 @@ describe RegistrationController do
         stub_json(CompetitionApi.url(@competition['id']), 200, @competition.except('qualifications'))
         stub_json(CompetitionApi.url("#{@competition['id']}/qualifications"), 200, @competition['qualifications'])
 
-        stub_request(:get, %r{#{Regexp.escape(EnvConfig.WCA_HOST)}/api/v0/results/\d+/qualification_data(\?date=\d{4}-\d{2}-\d{2})?}).
-          to_return(status: 502)
+        stub_request(:get, %r{#{Regexp.escape(EnvConfig.WCA_HOST)}/api/v0/results/\d+/qualification_data(\?date=\d{4}-\d{2}-\d{2})?})
+          .to_return(status: 502)
 
         stub_request(:post, EmailApi.registration_email_path).to_return(status: 200, body: { emails_sent: 1 }.to_json)
 
@@ -282,7 +282,7 @@ describe RegistrationController do
 
         expect(response.code).to eq('503')
       end
-      
+
       it 'UserApi::get_user_info_pii' do
         @competition = FactoryBot.build(:competition)
         stub_json(CompetitionApi.url(@competition['id']), 200, @competition.except('qualifications'))
@@ -304,6 +304,5 @@ describe RegistrationController do
         expect(response.code).to eq('503')
       end
     end
-
   end
 end

--- a/spec/controllers/registration_controller_spec.rb
+++ b/spec/controllers/registration_controller_spec.rb
@@ -235,4 +235,75 @@ describe RegistrationController do
       expect(response.code).to eq('400')
     end
   end
+
+  describe '#API errors' do
+    describe 'raise Registration error when monolith API fails:' do
+      it 'UserApi::get_permissions' do
+        @registration_request = FactoryBot.build(:registration_request)
+        stub_request(:get, UserApi.permissions_path(@registration_request['user_id'])).to_return(
+          status: 502,
+          headers: { 'Content-Type' => 'application/json' },
+        )
+
+        @competition = FactoryBot.build(:competition)
+        stub_request(:get, CompetitionApi.url(@competition['id'])).to_return(
+          status: 200,
+          body: @competition.except('qualifications').to_json,
+          headers: { 'Content-Type' => 'application/json' },
+        )
+
+        stub_request(:post, EmailApi.registration_email_path).to_return(status: 200, body: { emails_sent: 1 }.to_json)
+
+        request.headers['Authorization'] = @registration_request['jwt_token']
+        post :create, params: @registration_request, as: :json
+
+        expect(response.code).to eq('503')
+      end
+
+      it 'UserApi::qualifications' do
+        @registration_request = FactoryBot.build(:registration_request)
+        stub_request(:get, UserApi.permissions_path(@registration_request['user_id'])).to_return(
+          status: 200,
+          body: FactoryBot.build(:permissions).to_json,
+          headers: { 'Content-Type' => 'application/json' },
+        )
+
+        @competition = FactoryBot.build(:competition, :has_qualifications)
+        stub_json(CompetitionApi.url(@competition['id']), 200, @competition.except('qualifications'))
+        stub_json(CompetitionApi.url("#{@competition['id']}/qualifications"), 200, @competition['qualifications'])
+
+        stub_request(:get, %r{#{Regexp.escape(EnvConfig.WCA_HOST)}/api/v0/results/\d+/qualification_data(\?date=\d{4}-\d{2}-\d{2})?}).
+          to_return(status: 502)
+
+        stub_request(:post, EmailApi.registration_email_path).to_return(status: 200, body: { emails_sent: 1 }.to_json)
+
+        request.headers['Authorization'] = @registration_request['jwt_token']
+        post :create, params: @registration_request, as: :json
+
+        expect(response.code).to eq('503')
+      end
+      
+      it 'UserApi::get_user_info_pii' do
+        @competition = FactoryBot.build(:competition)
+        stub_json(CompetitionApi.url(@competition['id']), 200, @competition.except('qualifications'))
+
+        @requesting_user_id = 1400
+        stub_request(:get, UserApi.permissions_path(@requesting_user_id)).to_return(
+          status: 200,
+          body: FactoryBot.build(:permissions_response, organized_competitions: [@competition['id']]).to_json,
+          headers: { 'Content-Type' => 'application/json' },
+        )
+
+        registration = FactoryBot.create(:registration, registration_status: 'pending')
+
+        stub_request(:post, UserApi.competitor_info_path).to_return(status: 502)
+
+        request.headers['Authorization'] = fetch_jwt_token(@requesting_user_id)
+        get :list_admin, params: { competition_id: @competition['id'] }
+
+        expect(response.code).to eq('503')
+      end
+    end
+
+  end
 end

--- a/spec/support/stub_helper.rb
+++ b/spec/support/stub_helper.rb
@@ -25,3 +25,16 @@ def stub_qualifications(payload = nil, qualification_data_date = nil)
     end
   end
 end
+
+def stub_qualification_error
+  url_regex = %r{#{Regexp.escape(EnvConfig.WCA_HOST)}/api/v0/results/\d+/qualification_data(\?date=\d{4}-\d{2}-\d{2})?}
+
+  stub_request(:get, url_regex).to_return do |request|
+    uri = URI(request.uri)
+    params = URI.decode_www_form(uri.query || '').to_h
+    date = params['date']
+    payload_date = qualification_data_date || date
+
+    { status: 502 }
+  end
+end


### PR DESCRIPTION
Currently we haven't been checking for status code or raising errors when we don't get a 200 back from the monolith. This is a basic/non-comprehensive implementation of status codes for API endpoints that we call.

One thing I was wondering: If we get a 302/304 response, would that trigger a false-positive error message? Or is the server smart enough to still make it look like a 200?