### PR TITLE
Send update email only if status has changed

### DIFF
--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -130,7 +130,7 @@ class RegistrationController < ApplicationController
     end
 
     # Only send emails when we update the competing status
-    if status.present?
+    if status.present? && old_status != status
       EmailApi.send_update_email(@competition_id, user_id, status, @current_user)
     end
 


### PR DESCRIPTION
Currently our implementation of this relies on the assumption that if the status is present in the update request, it means that the status has changed. This isn't guaranteed, and we already have the `old_status` variable - so we may as well explicitly compare them and confirm that they are in fact different