### PR TITLE
Added check for registrations > competitor limit to also fail

### DIFF
--- a/app/services/registration_checker.rb
+++ b/app/services/registration_checker.rb
@@ -165,7 +165,7 @@ class RegistrationChecker
 
       raise RegistrationError.new(:unprocessable_entity, ErrorCodes::INVALID_REQUEST_DATA) unless Registration::REGISTRATION_STATES.include?(new_status)
       raise RegistrationError.new(:forbidden, ErrorCodes::COMPETITOR_LIMIT_REACHED) if
-        new_status == 'accepted' && Registration.accepted_competitors_count(@competition_info.competition_id) == @competition_info.competitor_limit
+        new_status == 'accepted' && Registration.accepted_competitors_count(@competition_info.competition_id) >= @competition_info.competitor_limit
 
       # Organizers cant accept someone from the waiting list who isn't in the leading position
       min_waiting_list_position = @registration.competing_lane.get_waiting_list_boundaries(@registration.competition_id)['waiting_list_position_min']

--- a/spec/services/registration_checker_spec.rb
+++ b/spec/services/registration_checker_spec.rb
@@ -1023,7 +1023,7 @@ describe RegistrationChecker do
         end
       end
 
-      it 'organizer cant accept a user when registration list is full' do
+      it 'organizer cant accept a user when registration list is exactly full' do
         FactoryBot.create_list(:registration, 3, registration_status: 'accepted')
         override_registration = FactoryBot.create(:registration, user_id: 188000, registration_status: 'waiting_list')
         override_competition_info = CompetitionInfo.new(FactoryBot.build(:competition, competitor_limit: 3))
@@ -1036,6 +1036,21 @@ describe RegistrationChecker do
           expect(error.http_status).to eq(:forbidden)
         end
       end
+
+      it 'organizer cant accept a user when registration list is over full' do
+        FactoryBot.create_list(:registration, 4, registration_status: 'accepted')
+        override_registration = FactoryBot.create(:registration, user_id: 188000, registration_status: 'waiting_list')
+        override_competition_info = CompetitionInfo.new(FactoryBot.build(:competition, competitor_limit: 3))
+        update_request = FactoryBot.build(:update_request, :organizer_for_user, user_id: override_registration[:user_id], competing: { 'status' => 'accepted' })
+
+        expect {
+          RegistrationChecker.update_registration_allowed!(update_request, override_competition_info, update_request['submitted_by'])
+        }.to raise_error(RegistrationError) do |error|
+          expect(error.error).to eq(ErrorCodes::COMPETITOR_LIMIT_REACHED)
+          expect(error.http_status).to eq(:forbidden)
+        end
+      end
+
 
       it 'organizer can accept registrations up to the limit' do
         FactoryBot.create_list(:registration, 2, registration_status: 'accepted')

--- a/spec/services/registration_checker_spec.rb
+++ b/spec/services/registration_checker_spec.rb
@@ -1051,7 +1051,6 @@ describe RegistrationChecker do
         end
       end
 
-
       it 'organizer can accept registrations up to the limit' do
         FactoryBot.create_list(:registration, 2, registration_status: 'accepted')
         registration = FactoryBot.create(:registration, registration_status: 'waiting_list')


### PR DESCRIPTION
Previously we only checked for exact equality when failing competitor limit check - so if somehow we end up with more accepted competitors than the competitor limit, then the organizer could keep approving registrations [or it would keep auto-accepting]. This fixes that issue.