### PR TITLE
Implement ranked qualification waiting list

### DIFF
--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -77,6 +77,10 @@ class Registration
     competing_lane&.lane_details&.[]('event_details')
   end
 
+  def event_details_for(event_id)
+    competing_lane.lane_details['event_details'].find { |e| e['event_id'] == event_id}
+  end
+
   def competing_waiting_list_position
     competing_lane&.lane_details&.[]('waiting_list_position')
   end
@@ -141,9 +145,12 @@ class Registration
           lane.lane_state = update_params[:status]
 
           lane.lane_details['event_details'].each do |event|
-            # NOTE: Currently event_registration_state is not used - when per-event registrations are added, we need to add validation logic to support cases like
-            # limited registrations and waiting lists for certain events
-            event['event_registration_state'] = update_params[:status]
+            competition = CompetitionApi.find(competition_id)
+            if competition.get_qualification_for(event['event_id'])['type'] == 'ranking' && update_params[:status] == 'accepted'
+              event['event_registration_state'] = 'waiting_list'
+            else
+              event['event_registration_state'] = update_params[:status]
+            end
           end
         end
 

--- a/lib/lane.rb
+++ b/lib/lane.rb
@@ -101,7 +101,6 @@ class Lane
   end
 
   private
-
     # Used for propagating a change in waiting_list_position to all affected registrations
     # increment_value is the value by which position should be shifted - usually 1 or -1
     # Lower waiting_list_position = higher up the waiting list (1 on waiting list will be accepted before 10)

--- a/lib/lane_factory.rb
+++ b/lib/lane_factory.rb
@@ -9,7 +9,7 @@ class LaneFactory
     competing_lane.completed_steps = ['Event Registration']
     competing_lane.lane_state = registration_status
     competing_lane.lane_details = {
-      'event_details' => event_ids.map { |event_id| { event_id: event_id, event_registration_state: registration_status } },
+      'event_details' => event_ids.map { |event_id| { 'event_id' => event_id, 'event_registration_state' => registration_status } },
       'comment' => comment,
       'admin_comment' => admin_comment,
       'waiting_list_position' => waiting_list_position.to_i,

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -33,7 +33,7 @@ describe Registration do
       { old_status: 'accepted', new_status: 'pending' },
       { old_status: 'accepted', new_status: 'waiting_list' },
     ].each do |params|
-        it_behaves_like 'competing_status updates', params[:old_status], params[:new_status]
+      it_behaves_like 'competing_status updates', params[:old_status], params[:new_status]
     end
   end
 

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -19,7 +19,6 @@ describe Registration do
   end
 
   describe '#update_competing_lane!', :tag do
-
     RSpec.shared_examples 'competing_status updates' do |old_status, new_status|
       it "given #{new_status}, #{old_status} updates as expected" do
         registration = FactoryBot.create(:registration, registration_status: old_status)

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -18,29 +18,23 @@ describe Registration do
     end
   end
 
-  describe '#update_competing_lane!' do
-    it 'given accepted status, it changes the users status to accepted' do
-      registration = FactoryBot.create(:registration, registration_status: 'pending')
-      registration.update_competing_lane!({ status: 'accepted' })
-      expect(registration.competing_status).to eq('accepted')
+  describe '#update_competing_lane!', :tag do
+
+    RSpec.shared_examples 'competing_status updates' do |old_status, new_status|
+      it "given #{new_status}, #{old_status} updates as expected" do
+        registration = FactoryBot.create(:registration, registration_status: old_status)
+        registration.update_competing_lane!({ status: new_status })
+        expect(registration.competing_status).to eq(new_status)
+      end
     end
 
-    it 'accepted given cancelled, it sets competing_status accordingly' do
-      registration = FactoryBot.create(:registration, registration_status: 'accepted')
-      registration.update_competing_lane!({ status: 'cancelled' })
-      expect(registration.competing_status).to eq('cancelled')
-    end
-
-    it 'accepted given pending, it sets competing_status accordingly' do
-      registration = FactoryBot.create(:registration, registration_status: 'accepted')
-      registration.update_competing_lane!({ status: 'pending' })
-      expect(registration.competing_status).to eq('pending')
-    end
-
-    it 'accepted given waiting_list, it sets competing_status' do
-      registration = FactoryBot.create(:registration, registration_status: 'accepted')
-      registration.update_competing_lane!({ status: 'waiting_list' })
-      expect(registration.competing_status).to eq('waiting_list')
+    [
+      { old_status: 'pending', new_status: 'accepted' },
+      { old_status: 'accepted', new_status: 'cancelled' },
+      { old_status: 'accepted', new_status: 'pending' },
+      { old_status: 'accepted', new_status: 'waiting_list' },
+    ].each do |params|
+        it_behaves_like 'competing_status updates', params[:old_status], params[:new_status]
     end
   end
 


### PR DESCRIPTION
The first of several event-specific waiting list PR's. This will create backend support for event-specific waiting lists in cases where ranked qualifications are used.

## Implementation Questions:
- [ ] Should we have model validations for consistency between competing_status and event_registration_state? Or is comprehensive testing enough? 
- [ ] This implementation requires the Registration model to call the competition API - are we ok with that? 

