### PR TITLE
Add hook to delay email sending in registration queue

### DIFF
--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -138,9 +138,6 @@ class RegistrationController < ApplicationController
       EmailApi.send_update_email(@competition_id, user_id, status, @current_user)
     end
 
-    # Invalidate cache
-    Rails.cache.delete("#{user_id}-registrations-by-user")
-
     {
       user_id: updated_registration['user_id'],
       guests: updated_registration.guests,

--- a/app/jobs/registration_processor.rb
+++ b/app/jobs/registration_processor.rb
@@ -17,7 +17,6 @@ class RegistrationProcessor < ApplicationJob
                          message[:created_at],
                          side_effects)
     end
-    Rails.cache.delete("#{message[:user_id]}-registrations-by-user")
     side_effects.run(:after_processing)
     Metrics.increment('registrations_processed')
   end

--- a/app/jobs/registration_processor.rb
+++ b/app/jobs/registration_processor.rb
@@ -7,7 +7,7 @@ class RegistrationProcessor < ApplicationJob
 
   def perform(message)
     Rails.logger.debug { "Working on Message: #{message}" }
-    hooks = JobHooks.new
+    side_effects = JobSideEffects.new
     if message[:step] == 'EventRegistration'
       event_registration(message[:competition_id],
                          message[:user_id],
@@ -15,17 +15,17 @@ class RegistrationProcessor < ApplicationJob
                          message[:step_details][:comment],
                          message[:step_details][:guests],
                          message[:created_at],
-                         hooks)
+                         side_effects)
     end
     Rails.cache.delete("#{message[:user_id]}-registrations-by-user")
-    hooks.run(:after_processing)
+    side_effects.run(:after_processing)
     Metrics.increment('registrations_processed')
   end
 
   private
 
     # rubocop:disable Metrics/ParameterLists
-    def event_registration(competition_id, user_id, event_ids, comment, guests, created_at, hooks)
+    def event_registration(competition_id, user_id, event_ids, comment, guests, created_at, side_effects)
       # Event Registration might not be the first lane that is completed
       # TODO: When we add another lane, we need to update the registration history instead of creating it
       registration = begin
@@ -49,7 +49,7 @@ class RegistrationProcessor < ApplicationJob
       else
         registration.update_attributes(lanes: registration.lanes.append(competing_lane), guests: guests)
       end
-      hooks.after_processing do
+      side_effects.after_processing do
         EmailApi.send_creation_email(competition_id, user_id)
       end
     end

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -14,6 +14,10 @@ class Registration
   # Pre-validations
   before_validation :set_competing_status
 
+  # Hooks
+  after_create :delete_user_registration_from_redis
+  after_update :delete_user_registration_from_redis
+
   # Validations
   validate :competing_status_consistency
 
@@ -215,5 +219,9 @@ class Registration
       lane_state_present = competing_status == 'waiting_list' || update_params[:status] == 'waiting_list'
       states_are_different = competing_status != update_params[:status]
       lane_state_present && states_are_different
+    end
+
+    def delete_user_registration_from_redis
+      RedisHelper.delete_user_registrations(user_id)
     end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       REGISTRATION_HISTORY_DYNAMO_TABLE: "registration-history-development"
       CODE_ENVIRONMENT: "development"
       QUEUE_NAME: "registrations.fifo"
+      REDIS_URL: "redis://redis:6379"
     volumes:
       - .:/app
       - gems_volume_worker:/usr/local/bundle

--- a/lib/job_hooks.rb
+++ b/lib/job_hooks.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class JobHooks
+  attr_writer :after_processing
+
+  def initialize
+    @after_processing = []
+  end
+
+  def after_processing(&blk)
+    @after_processing << blk
+  end
+
+  def run(hook)
+    defined_hooks = self.instance_variable_get(:"@#{hook}")
+    defined_hooks.each(&:call)
+  end
+end

--- a/lib/job_side_effects.rb
+++ b/lib/job_side_effects.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class JobHooks
+class JobSideEffects
   attr_writer :after_processing
 
   def initialize

--- a/lib/redis_helper.rb
+++ b/lib/redis_helper.rb
@@ -9,6 +9,10 @@ module RedisHelper
     end
   end
 
+  def self.delete_user_registrations(user_id)
+    Rails.cache.delete("#{user_id}-registrations-by-user")
+  end
+
   def self.decrement_or_initialize(key, &)
     if Rails.cache.exist?(key)
       Rails.cache.decrement(key)


### PR DESCRIPTION
My attempt at resolving the chicken-and-egg problem with email sendout after intitial registration.

Might feel a bit overkill because right now we only have one step for one lane, but may get useful later down the road if we have more complex processing logic