### PR TITLE
Allow organizers to approve registrations when there is no competitor limit

### DIFF
--- a/app/services/registration_checker.rb
+++ b/app/services/registration_checker.rb
@@ -174,9 +174,8 @@ class RegistrationChecker
       raise RegistrationError.new(:unprocessable_entity, ErrorCodes::INVALID_REQUEST_DATA) unless Registration::REGISTRATION_STATES.include?(new_status)
 
       competitor_limit = @competition_info.competitor_limit
-      accepted_competitors = Registration.accepted_competitors_count(@competition_info.competition_id)
       raise RegistrationError.new(:forbidden, ErrorCodes::COMPETITOR_LIMIT_REACHED) if
-        new_status == 'accepted' && competitor_limit > 0 && accepted_competitors == competitor_limit
+        new_status == 'accepted' && competitor_limit > 0 && Registration.accepted_competitors_count(@competition_info.competition_id) >= competitor_limit
 
       raise RegistrationError.new(:forbidden, ErrorCodes::ALREADY_REGISTERED_IN_SERIES) if
         new_status == 'accepted' && existing_registration_in_series?

--- a/app/services/registration_checker.rb
+++ b/app/services/registration_checker.rb
@@ -173,7 +173,8 @@ class RegistrationChecker
 
       raise RegistrationError.new(:unprocessable_entity, ErrorCodes::INVALID_REQUEST_DATA) unless Registration::REGISTRATION_STATES.include?(new_status)
       raise RegistrationError.new(:forbidden, ErrorCodes::COMPETITOR_LIMIT_REACHED) if
-        new_status == 'accepted' && Registration.accepted_competitors_count(@competition_info.competition_id) == @competition_info.competitor_limit
+        new_status == 'accepted' && Registration.accepted_competitors_count(@competition_info.competition_id) == @competition_info.competitor_limit &&
+        @competition_info.competitor_limit != 0
       raise RegistrationError.new(:forbidden, ErrorCodes::ALREADY_REGISTERED_IN_SERIES) if
         new_status == 'accepted' && existing_registration_in_series?
 

--- a/app/services/registration_checker.rb
+++ b/app/services/registration_checker.rb
@@ -172,9 +172,12 @@ class RegistrationChecker
       current_status = @registration.competing_status
 
       raise RegistrationError.new(:unprocessable_entity, ErrorCodes::INVALID_REQUEST_DATA) unless Registration::REGISTRATION_STATES.include?(new_status)
+
+      competitor_limit = @competition_info.competitor_limit
+      accepted_competitors = Registration.accepted_competitors_count(@competition_info.competition_id)
       raise RegistrationError.new(:forbidden, ErrorCodes::COMPETITOR_LIMIT_REACHED) if
-        new_status == 'accepted' && Registration.accepted_competitors_count(@competition_info.competition_id) == @competition_info.competitor_limit &&
-        @competition_info.competitor_limit != 0
+        new_status == 'accepted' && competitor_limit > 0 && accepted_competitors == competitor_limit
+
       raise RegistrationError.new(:forbidden, ErrorCodes::ALREADY_REGISTERED_IN_SERIES) if
         new_status == 'accepted' && existing_registration_in_series?
 

--- a/lib/competition_info.rb
+++ b/lib/competition_info.rb
@@ -45,7 +45,7 @@ class CompetitionInfo
   end
 
   def registration_open?
-  @competition_json['registration_open'] <= Time.now && @competition_json['registration_close'] > Time.now
+    @competition_json['registration_open'] <= Time.now.utc && @competition_json['registration_close'] > Time.now.utc
   end
 
   def using_wca_payment?

--- a/spec/services/registration_checker_spec.rb
+++ b/spec/services/registration_checker_spec.rb
@@ -1104,6 +1104,15 @@ describe RegistrationChecker do
           .not_to raise_error
       end
 
+      it 'organizer can accept registrations if there is no limit' do
+        registration = FactoryBot.create(:registration, registration_status: 'pending')
+        competition_info = CompetitionInfo.new(FactoryBot.build(:competition, competitor_limit: 0))
+        update_request = FactoryBot.build(:update_request, :organizer_for_user, user_id: registration[:user_id], competing: { 'status' => 'accepted' })
+
+        expect { RegistrationChecker.update_registration_allowed!(update_request, competition_info, update_request['submitted_by']) }
+          .not_to raise_error
+      end
+
       it 'user can change state to cancelled' do
         override_registration = FactoryBot.create(:registration, user_id: 188000, registration_status: 'waiting_list')
         update_request = FactoryBot.build(:update_request, user_id: override_registration[:user_id], competing: { 'status' => 'cancelled' })


### PR DESCRIPTION
This fixes an issue reported for TexasFMCChampionship2024