### PR TITLE
Default competitor limit to 0 if null

### DIFF
--- a/app/services/registration_checker.rb
+++ b/app/services/registration_checker.rb
@@ -173,7 +173,7 @@ class RegistrationChecker
 
       raise RegistrationError.new(:unprocessable_entity, ErrorCodes::INVALID_REQUEST_DATA) unless Registration::REGISTRATION_STATES.include?(new_status)
 
-      competitor_limit = @competition_info.competitor_limit
+      competitor_limit = @competition_info.competitor_limit || 0
       raise RegistrationError.new(:forbidden, ErrorCodes::COMPETITOR_LIMIT_REACHED) if
         new_status == 'accepted' && competitor_limit > 0 && Registration.accepted_competitors_count(@competition_info.competition_id) >= competitor_limit
 

--- a/spec/services/registration_checker_spec.rb
+++ b/spec/services/registration_checker_spec.rb
@@ -1127,6 +1127,15 @@ describe RegistrationChecker do
           .not_to raise_error
       end
 
+      it 'organizer can accept registrations limit is nil' do
+        registration = FactoryBot.create(:registration, registration_status: 'pending')
+        competition_info = CompetitionInfo.new(FactoryBot.build(:competition, competitor_limit: nil))
+        update_request = FactoryBot.build(:update_request, :organizer_for_user, user_id: registration[:user_id], competing: { 'status' => 'accepted' })
+
+        expect { RegistrationChecker.update_registration_allowed!(update_request, competition_info, update_request['submitted_by']) }
+          .not_to raise_error
+      end
+
       it 'user can change state to cancelled' do
         override_registration = FactoryBot.create(:registration, user_id: 188000, registration_status: 'waiting_list')
         update_request = FactoryBot.build(:update_request, user_id: override_registration[:user_id], competing: { 'status' => 'cancelled' })


### PR DESCRIPTION
After seeing [TexasFMCChampionship](https://www.worldcubeassociation.org/api/v0/competitions/TexasFMCChampionship2024), I thought all comps without a competitor limit were defaulted to 0.

However, [FMCArgentina](https://www.worldcubeassociation.org/api/v0/competitions/FMCArgentina2024) has a competitor_limit of null in the JSON payload.

As a hotfix for v2, I'm defaulting competitor_limit to 0 if it is nil. 

The better approach is what we're now using in v3, which is to query the `competitor_limit_enabled` property directly. We could expose this in the competition JSON, but given that we want to phase out v2 soon it didn't seem necessary.